### PR TITLE
Add spec coverage for Railtie.

### DIFF
--- a/lib/stitch_fix/log_weasel/railtie.rb
+++ b/lib/stitch_fix/log_weasel/railtie.rb
@@ -6,10 +6,10 @@ module StitchFix
 
     initializer "log_weasel.configure" do |app|
       LogWeasel.configure do |config|
-        config.key = app.config.log_weasel[:key] || self.app_name
+        config.key = app.config.log_weasel[:key] || LogWeasel::Railtie.app_name
       end
 
-      app.config.middleware.insert_before "::ActionDispatch::RequestId", LogWeasel::Middleware
+      app.config.middleware.insert_before ::ActionDispatch::RequestId, LogWeasel::Middleware
     end
 
     private

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,11 @@
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
+require 'combustion'
 require 'stitch_fix/log_weasel'
+
+Combustion.initialize! :active_support
+
 require 'rspec'
 
 begin

--- a/stitchfix-log_weasel.gemspec
+++ b/stitchfix-log_weasel.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec')
   s.add_development_dependency('rspec_junit_formatter')
   s.add_development_dependency('stitchfix-y')
+  s.add_development_dependency('combustion')
 
   s.add_dependency('activesupport')
 


### PR DESCRIPTION
The addresses an issue that @FreekingDean ran into while updating the `api_client` gem in Kingmob.

Tracker: https://www.pivotaltracker.com/story/show/145729071

Solution: Added the `combustion` gem so the Railtie gets loaded (and thus, tested) when specs are run.