### PR TITLE
Bug/149199523 unique uuid for calls made from Resque [#149199523]

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,19 @@ Load and configure Log Weasel with:
 <pre>
 LogWeasel.configure do |config|
   config.key = "YOUR_APP"
+  config.disable_delayed_job_tracing = false
 end
 </pre>
 
-<code>config.key</code> is a string that will be included in your transaction IDs and is particularly
-useful in an environment where a unit of work may span multiple applications. It is optional but you must call
-<code>LogWeasel.configure</code>.
+<code>config.key</code>  (default is the Rails `app_name`)  
+A string that will be included in your transaction IDs and is particularly
+useful in an environment where a unit of work may span multiple applications.  
+
+<code>config.disable_delayed_job_tracing</code> (default is `false`)  
+A boolean that disables Log Weasel appending a `log_weasel_id` parameter in 
+the payloads of delayed Resque jobs. The default is `false`. 
+ 
+Setting these configuration options are optional, but you must call <code>LogWeasel.configure</code>.
 
 ### Rack
 

--- a/lib/stitch_fix/log_weasel.rb
+++ b/lib/stitch_fix/log_weasel.rb
@@ -3,7 +3,9 @@ require 'stitch_fix/log_weasel/logger'
 require 'stitch_fix/log_weasel/airbrake'
 require 'stitch_fix/log_weasel/middleware'
 require 'stitch_fix/log_weasel/resque'
+require 'stitch_fix/log_weasel/resque_scheduler'
 require 'stitch_fix/log_weasel/pwwka'
+require 'stitch_fix/log_weasel/monkey_patches'
 require 'stitch_fix/log_weasel/railtie' if defined? ::Rails::Railtie
 
 module StitchFix
@@ -33,6 +35,9 @@ module StitchFix
         StitchFix::LogWeasel::Resque.initialize!
       end
 
+      if defined? ::Resque::Scheduler
+        StitchFix::LogWeasel::ResqueScheduler.initialize!
+      end
     end
   end
 end

--- a/lib/stitch_fix/log_weasel.rb
+++ b/lib/stitch_fix/log_weasel.rb
@@ -11,7 +11,12 @@ require 'stitch_fix/log_weasel/railtie' if defined? ::Rails::Railtie
 module StitchFix
   module LogWeasel
     class Config
-      attr_accessor :key
+      attr_accessor :key, :disable_delayed_job_tracing
+
+      def disable_delayed_job_tracing?
+        @disable_delayed_job_tracing ||
+          (defined?(Rails) && Rails.env.test?)
+      end
     end
 
     def self.config

--- a/lib/stitch_fix/log_weasel/monkey_patches.rb
+++ b/lib/stitch_fix/log_weasel/monkey_patches.rb
@@ -11,7 +11,7 @@ module Resque
 
     def self.setup_log_weasel_transaction_id(config)
       if config["args"].is_a?(Array)
-        log_weasel_payload = config["args"].detect { |arg| arg.is_a?(Hash) && arg["log_weasel_id"] }
+        log_weasel_payload = config["args"].detect { |arg| arg.is_a?(Hash) && arg.keys.include?("log_weasel_id") }
         if log_weasel_payload
           puts "A log_weasel_id was found in the job payload. Setting the current Transaction id to it."
           StitchFix::LogWeasel::Transaction.id = log_weasel_payload["log_weasel_id"]

--- a/lib/stitch_fix/log_weasel/monkey_patches.rb
+++ b/lib/stitch_fix/log_weasel/monkey_patches.rb
@@ -1,3 +1,5 @@
+require 'resque-scheduler'
+
 module Resque
   module Scheduler
     # Example config:

--- a/lib/stitch_fix/log_weasel/monkey_patches.rb
+++ b/lib/stitch_fix/log_weasel/monkey_patches.rb
@@ -1,0 +1,28 @@
+module Resque
+  module Scheduler
+    # Example config:
+    # {"class"=>"EchoJob", "args"=>["delayed hello from HelloController", {"log_weasel_id"=>"HELLBLAZER-WEB-27c2d9bb1f3a28474b10"}]}
+    def self.enqueue_with_log_weasel(config)
+      setup_log_weasel_transaction_id(config)
+      enqueue_without_log_weasel(config)
+    end
+
+    def self.setup_log_weasel_transaction_id(config)
+      if config["args"].is_a?(Array)
+        log_weasel_payload = config["args"].detect { |arg| arg.is_a?(Hash) && arg["log_weasel_id"] }
+        if log_weasel_payload
+          puts "A log_weasel_id was found in the job payload. Setting the current Transaction id to it."
+          StitchFix::LogWeasel::Transaction.id = log_weasel_payload["log_weasel_id"]
+          puts "Removing the log_weasel_id from the payload."
+          config["args"] = config["args"] - [log_weasel_payload]
+        end
+      else
+        puts "Initializing log weasel transaction ID"
+        StitchFix::LogWeasel::Transaction.id = nil
+      end
+    end
+
+    singleton_class.send(:alias_method, :enqueue_without_log_weasel, :enqueue)
+    singleton_class.send(:alias_method, :enqueue, :enqueue_with_log_weasel)
+  end
+end

--- a/lib/stitch_fix/log_weasel/pwwka.rb
+++ b/lib/stitch_fix/log_weasel/pwwka.rb
@@ -2,8 +2,13 @@ module StitchFix
   module LogWeasel::Pwwka
 
     def self.initialize!
+      @pwwka ||= setup
+    end
+
+    def self.setup
       ::Pwwka::Logging.send(:include, LogWeasel::Pwwka::Logging)
       ::Pwwka::PublishOptions.send(:include, LogWeasel::Pwwka::PublishOptions)
+      true
     end
 
     # This is called from tasks.rb in message_handler:before_receive

--- a/lib/stitch_fix/log_weasel/pwwka.rb
+++ b/lib/stitch_fix/log_weasel/pwwka.rb
@@ -4,12 +4,10 @@ module StitchFix
     def self.initialize!
       ::Pwwka::Logging.send(:include, LogWeasel::Pwwka::Logging)
       ::Pwwka::PublishOptions.send(:include, LogWeasel::Pwwka::PublishOptions)
-      # ::Pwwka::Transmitter.send(:include, LogWeasel::Pwwka::InstanceMethods)
     end
 
     module Logging
       def logf_with_transaction_id(format, params)
-        puts "from logf_with_transaction_id params: #{params}"
         logf_without_transaction_id "[#{LogWeasel::Transaction.id}] #{format}", params
       end
 
@@ -21,9 +19,7 @@ module StitchFix
 
     module PublishOptions
       def to_h_with_correlation_id
-        puts "PublishOptions#to_h_with_correlation_id"
-        key = LogWeasel.config.key ? "#{LogWeasel.config.key}-PWWKA" : "PWWKA"
-        to_h_without_correlation_id.merge(correlation_id: LogWeasel::Transaction.id || LogWeasel::Transaction.create(key))
+        to_h_without_correlation_id.merge(correlation_id: LogWeasel::Transaction.id)
       end
 
       def self.included(base)

--- a/lib/stitch_fix/log_weasel/pwwka.rb
+++ b/lib/stitch_fix/log_weasel/pwwka.rb
@@ -3,16 +3,32 @@ module StitchFix
 
     def self.initialize!
       ::Pwwka::Logging.send(:include, LogWeasel::Pwwka::Logging)
+      ::Pwwka::PublishOptions.send(:include, LogWeasel::Pwwka::PublishOptions)
+      # ::Pwwka::Transmitter.send(:include, LogWeasel::Pwwka::InstanceMethods)
     end
 
     module Logging
       def logf_with_transaction_id(format, params)
+        puts "from logf_with_transaction_id params: #{params}"
         logf_without_transaction_id "[#{LogWeasel::Transaction.id}] #{format}", params
       end
 
       def self.included(base)
         base.send :alias_method, :logf_without_transaction_id, :logf
         base.send :alias_method, :logf, :logf_with_transaction_id
+      end
+    end
+
+    module PublishOptions
+      def to_h_with_correlation_id
+        puts "PublishOptions#to_h_with_correlation_id"
+        key = LogWeasel.config.key ? "#{LogWeasel.config.key}-PWWKA" : "PWWKA"
+        to_h_without_correlation_id.merge(correlation_id: LogWeasel::Transaction.id || LogWeasel::Transaction.create(key))
+      end
+
+      def self.included(base)
+        base.send :alias_method, :to_h_without_correlation_id, :to_h
+        base.send :alias_method, :to_h, :to_h_with_correlation_id
       end
     end
   end

--- a/lib/stitch_fix/log_weasel/pwwka.rb
+++ b/lib/stitch_fix/log_weasel/pwwka.rb
@@ -6,6 +6,7 @@ module StitchFix
       ::Pwwka::PublishOptions.send(:include, LogWeasel::Pwwka::PublishOptions)
     end
 
+    # This is called from tasks.rb in message_handler:before_receive
     def self.enhance_message_handler(klass)
       klass.define_singleton_method(:handle_with_log_weasel) do |delivery_info, properties, payload|
         LogWeasel::Transaction.id = properties[:correlation_id] if properties[:correlation_id]

--- a/lib/stitch_fix/log_weasel/railtie.rb
+++ b/lib/stitch_fix/log_weasel/railtie.rb
@@ -6,7 +6,7 @@ module StitchFix
 
     initializer "log_weasel.configure" do |app|
       LogWeasel.configure do |config|
-        config.key = app.config.log_weasel[:key] || LogWeasel::Railtie.app_name
+        config.key = app.config.log_weasel[:key] || LogWeasel::Railtie.app_name.upcase
       end
 
       app.config.middleware.insert_before ::ActionDispatch::RequestId, LogWeasel::Middleware

--- a/lib/stitch_fix/log_weasel/resque.rb
+++ b/lib/stitch_fix/log_weasel/resque.rb
@@ -26,7 +26,7 @@ module StitchFix
         end
       end
 
-      def self.before_push(queue, item, key)
+      def self.before_push(_queue, item, key)
         item['context'] = {'log_weasel_id' => (LogWeasel::Transaction.id || LogWeasel::Transaction.create(key))}
       end
     end

--- a/lib/stitch_fix/log_weasel/resque.rb
+++ b/lib/stitch_fix/log_weasel/resque.rb
@@ -32,15 +32,14 @@ module StitchFix
       end
 
       def self.before_push(_queue, item, key)
-        # Strip out log_weasel_id, if present
-        puts "in before_push"
+        # Strip out log_weasel_id, if it is present.
+        # This is possible if a delayed job (with a log_weasel_id appended to the job arguments)
+        # fails, and is later retried from Resque web.
         if item[:args].is_a?(Array)
           log_weasel_payload = item[:args].detect { |arg| arg.is_a?(Hash) && arg.keys.include?("log_weasel_id") }
           if log_weasel_payload
-            puts "A log_weasel_id was found in the job payload. Removing it."
+            LogWeasel::Transaction.id = log_weasel_payload["log_weasel_id"]
             item[:args] = item[:args] - [log_weasel_payload]
-          else
-            puts "No log_weasel_id present in args"
           end
         end
 

--- a/lib/stitch_fix/log_weasel/resque.rb
+++ b/lib/stitch_fix/log_weasel/resque.rb
@@ -32,6 +32,18 @@ module StitchFix
       end
 
       def self.before_push(_queue, item, key)
+        # Strip out log_weasel_id, if present
+        puts "in before_push"
+        if item[:args].is_a?(Array)
+          log_weasel_payload = item[:args].detect { |arg| arg.is_a?(Hash) && arg.keys.include?("log_weasel_id") }
+          if log_weasel_payload
+            puts "A log_weasel_id was found in the job payload. Removing it."
+            item[:args] = item[:args] - [log_weasel_payload]
+          else
+            puts "No log_weasel_id present in args"
+          end
+        end
+
         item['context'] = {'log_weasel_id' => (LogWeasel::Transaction.id || LogWeasel::Transaction.create(key))}
       end
     end

--- a/lib/stitch_fix/log_weasel/resque.rb
+++ b/lib/stitch_fix/log_weasel/resque.rb
@@ -1,7 +1,11 @@
 module StitchFix
   module LogWeasel::Resque
 
-    def self.initialize!(options = {})
+    def self.initialize!
+      @@resque ||= setup
+    end
+
+    def self.setup
       ::Resque::Worker.send(:include, LogWeasel::Resque::Worker)
       ::Resque::Job.send(:include, LogWeasel::Resque::Job)
       ::Resque.extend(LogWeasel::Resque::ClassMethods)
@@ -15,6 +19,7 @@ module StitchFix
       ::Resque.before_push do |queue, item|
         LogWeasel::Resque::Callbacks.before_push queue, item, key
       end
+      true
     end
 
     module Callbacks

--- a/lib/stitch_fix/log_weasel/resque_scheduler.rb
+++ b/lib/stitch_fix/log_weasel/resque_scheduler.rb
@@ -13,13 +13,11 @@ module StitchFix
     module Env
       # To instrument resque:scheduler rake task with Log Weasel
       def setup_with_log_weasel
-        setup_without_log_weasel
-
         puts "initializing Log Weasel"
-        require "stitch_fix/log_weasel"
         key = defined?(::Rails::Railtie) ? StitchFix::LogWeasel::Railtie.app_name.upcase : nil
-        key ? "#{key}-RESQUE" : "RESQUE"
+        key ? "#{key}-RESQUE-SCHED" : "RESQUE-SCHED"
         StitchFix::LogWeasel.configure { |config| config.key = key }
+        setup_without_log_weasel
       end
 
       def self.included(base)

--- a/lib/stitch_fix/log_weasel/resque_scheduler.rb
+++ b/lib/stitch_fix/log_weasel/resque_scheduler.rb
@@ -8,10 +8,8 @@ module StitchFix
     end
 
     def self.setup
-      unless defined?(::Rails) && ::Rails.env.test?
-        ::Resque::Scheduler::DelayingExtensions.send(:include, LogWeasel::ResqueScheduler::DelayingExtensions)
-        ::Resque::Scheduler::Env.send(:include, LogWeasel::ResqueScheduler::Env)
-      end
+      ::Resque::Scheduler::DelayingExtensions.send(:include, LogWeasel::ResqueScheduler::DelayingExtensions)
+      ::Resque::Scheduler::Env.send(:include, LogWeasel::ResqueScheduler::Env)
       true
     end
 
@@ -20,7 +18,7 @@ module StitchFix
       def setup_with_log_weasel
         puts "initializing Log Weasel"
         key = defined?(::Rails::Railtie) ? StitchFix::LogWeasel::Railtie.app_name.upcase : nil
-        key ? "#{key}-RESQUE-SCHED" : "RESQUE-SCHED"
+        key ? "#{key}-RESQUE" : "RESQUE"
         StitchFix::LogWeasel.configure { |config| config.key = key }
         setup_without_log_weasel
       end

--- a/lib/stitch_fix/log_weasel/resque_scheduler.rb
+++ b/lib/stitch_fix/log_weasel/resque_scheduler.rb
@@ -14,8 +14,7 @@ module StitchFix
         setup_without_log_weasel
 
         puts "initializing Log Weasel"
-        # TODO: Use the correct library path below
-        require "/Users/brettfishman/dev/log_weasel/lib/stitch_fix/log_weasel"
+        require "stitch_fix/log_weasel"
         key = defined?(::Rails::Railtie) ? StitchFix::LogWeasel::Railtie.app_name.upcase : nil
         key ? "#{key}-RESQUE" : "RESQUE"
         StitchFix::LogWeasel.configure { |config| config.key = key }

--- a/lib/stitch_fix/log_weasel/resque_scheduler.rb
+++ b/lib/stitch_fix/log_weasel/resque_scheduler.rb
@@ -1,0 +1,44 @@
+require 'resque/scheduler/env'
+
+module StitchFix
+  module LogWeasel::ResqueScheduler
+
+    def self.initialize!(options = {})
+      ::Resque::Scheduler::DelayingExtensions.send(:include, LogWeasel::ResqueScheduler::DelayingExtensions)
+      ::Resque::Scheduler::Env.send(:include, LogWeasel::ResqueScheduler::Env)
+    end
+
+    module Env
+      # To instrument resque:scheduler rake task with Log Weasel
+      def setup_with_log_weasel
+        setup_without_log_weasel
+
+        puts "initializing Log Weasel"
+        # TODO: Use the correct library path below
+        require "/Users/brettfishman/dev/log_weasel/lib/stitch_fix/log_weasel"
+        key = defined?(::Rails::Railtie) ? StitchFix::LogWeasel::Railtie.app_name.upcase : nil
+        key ? "#{key}-RESQUE" : "RESQUE"
+        StitchFix::LogWeasel.configure { |config| config.key = key }
+      end
+
+      def self.included(base)
+        base.send :alias_method, :setup_without_log_weasel, :setup
+        base.send :alias_method, :setup, :setup_with_log_weasel
+      end
+    end
+
+    module DelayingExtensions
+      # This adds the Log Weasel txn ID to the delayed/scheduled
+      # Resque job payloads.
+      def job_to_hash_with_queue_and_lid(queue, klass, args)
+        args << { "log_weasel_id" => LogWeasel::Transaction.id }
+        job_to_hash_with_queue_without_lid(queue, klass, args)
+      end
+
+      def self.included(base)
+        base.send :alias_method, :job_to_hash_with_queue_without_lid, :job_to_hash_with_queue
+        base.send :alias_method, :job_to_hash_with_queue, :job_to_hash_with_queue_and_lid
+      end
+    end
+  end
+end

--- a/lib/stitch_fix/log_weasel/resque_scheduler.rb
+++ b/lib/stitch_fix/log_weasel/resque_scheduler.rb
@@ -3,11 +3,16 @@ require 'resque/scheduler/env'
 module StitchFix
   module LogWeasel::ResqueScheduler
 
-    def self.initialize!(options = {})
+    def self.initialize!
+      @@resque_scheduler ||= setup
+    end
+
+    def self.setup
       unless defined?(::Rails) && ::Rails.env.test?
         ::Resque::Scheduler::DelayingExtensions.send(:include, LogWeasel::ResqueScheduler::DelayingExtensions)
         ::Resque::Scheduler::Env.send(:include, LogWeasel::ResqueScheduler::Env)
       end
+      true
     end
 
     module Env

--- a/lib/stitch_fix/log_weasel/resque_scheduler.rb
+++ b/lib/stitch_fix/log_weasel/resque_scheduler.rb
@@ -33,7 +33,7 @@ module StitchFix
       # This adds the Log Weasel txn ID to the delayed/scheduled
       # Resque job payloads, except in Rails test env.
       def job_to_hash_with_queue_and_lid(queue, klass, args)
-        unless defined?(::Rails) && ::Rails.env.test?
+        unless LogWeasel.config.disable_delayed_job_tracing?
           args << {"log_weasel_id" => LogWeasel::Transaction.id}
         end
         job_to_hash_with_queue_without_lid(queue, klass, args)

--- a/lib/stitch_fix/log_weasel/resque_scheduler.rb
+++ b/lib/stitch_fix/log_weasel/resque_scheduler.rb
@@ -4,8 +4,10 @@ module StitchFix
   module LogWeasel::ResqueScheduler
 
     def self.initialize!(options = {})
-      ::Resque::Scheduler::DelayingExtensions.send(:include, LogWeasel::ResqueScheduler::DelayingExtensions)
-      ::Resque::Scheduler::Env.send(:include, LogWeasel::ResqueScheduler::Env)
+      unless defined?(::Rails) && ::Rails.env.test?
+        ::Resque::Scheduler::DelayingExtensions.send(:include, LogWeasel::ResqueScheduler::DelayingExtensions)
+        ::Resque::Scheduler::Env.send(:include, LogWeasel::ResqueScheduler::Env)
+      end
     end
 
     module Env

--- a/lib/stitch_fix/log_weasel/resque_scheduler.rb
+++ b/lib/stitch_fix/log_weasel/resque_scheduler.rb
@@ -31,9 +31,11 @@ module StitchFix
 
     module DelayingExtensions
       # This adds the Log Weasel txn ID to the delayed/scheduled
-      # Resque job payloads.
+      # Resque job payloads, except in Rails test env.
       def job_to_hash_with_queue_and_lid(queue, klass, args)
-        args << { "log_weasel_id" => LogWeasel::Transaction.id }
+        unless defined?(::Rails) && ::Rails.env.test?
+          args << {"log_weasel_id" => LogWeasel::Transaction.id}
+        end
         job_to_hash_with_queue_without_lid(queue, klass, args)
       end
 

--- a/lib/stitch_fix/log_weasel/tasks.rb
+++ b/lib/stitch_fix/log_weasel/tasks.rb
@@ -4,12 +4,12 @@ require 'resque/tasks'
 require 'resque-scheduler'
 
 namespace :resque do
-  desc "Add Log Weasel setup to resque:scheduler setup task"
-  task :add_log_weasel_setup do
+  desc "Adds Log Weasel setup to resque:scheduler setup task"
+  task :log_weasel_setup do
     StitchFix::LogWeasel::ResqueScheduler.initialize!
   end
 end
 
 Rake::Task['resque:scheduler_setup'].enhance do
-  Rake::Task['resque:add_log_weasel_setup'].invoke
+  Rake::Task['resque:log_weasel_setup'].invoke
 end

--- a/lib/stitch_fix/log_weasel/tasks.rb
+++ b/lib/stitch_fix/log_weasel/tasks.rb
@@ -1,0 +1,15 @@
+# vim:fileencoding=utf-8
+
+require 'resque/tasks'
+require 'resque-scheduler'
+
+namespace :resque do
+  desc "Add Log Weasel setup to resque:scheduler setup task"
+  task :add_log_weasel_setup do
+    StitchFix::LogWeasel::ResqueScheduler.initialize!
+  end
+end
+
+Rake::Task['resque:scheduler_setup'].enhance do
+  Rake::Task['resque:add_log_weasel_setup'].invoke
+end

--- a/lib/stitch_fix/log_weasel/tasks.rb
+++ b/lib/stitch_fix/log_weasel/tasks.rb
@@ -1,5 +1,6 @@
 # vim:fileencoding=utf-8
 
+require 'pwwka/tasks'
 require 'resque/tasks'
 require 'resque-scheduler'
 
@@ -10,6 +11,17 @@ namespace :resque do
   end
 end
 
-Rake::Task['resque:scheduler_setup'].enhance do
-  Rake::Task['resque:log_weasel_setup'].invoke
+Rake::Task["resque:scheduler_setup"].enhance do
+  Rake::Task["resque:log_weasel_setup"].invoke
+end
+
+namespace :message_handler do
+  desc "Decorate the message handler class with log weasel methods"
+  task :before_receive => :environment do
+    raise "HANDLER_KLASS must be set" unless ENV['HANDLER_KLASS']
+    handler_klass = ENV["HANDLER_KLASS"].constantize
+    StitchFix::LogWeasel::Pwwka.enhance_message_handler(handler_klass)
+  end
+
+  task :receive => :before_receive
 end

--- a/lib/stitch_fix/log_weasel/tasks.rb
+++ b/lib/stitch_fix/log_weasel/tasks.rb
@@ -2,7 +2,7 @@
 
 require 'pwwka/tasks'
 require 'resque/tasks'
-require 'resque-scheduler'
+require 'resque/scheduler/tasks'
 
 namespace :resque do
   desc "Adds Log Weasel setup to resque:scheduler setup task"

--- a/lib/stitch_fix/log_weasel/version.rb
+++ b/lib/stitch_fix/log_weasel/version.rb
@@ -1,5 +1,5 @@
 module StitchFix
   module LogWeasel
-    VERSION = '1.1.0.rc1'
+    VERSION = '1.1.0.rc2'
   end
 end

--- a/lib/stitch_fix/log_weasel/version.rb
+++ b/lib/stitch_fix/log_weasel/version.rb
@@ -1,5 +1,5 @@
 module StitchFix
   module LogWeasel
-    VERSION = '1.1.0.rc3'
+    VERSION = '1.1.0.rc4'
   end
 end

--- a/lib/stitch_fix/log_weasel/version.rb
+++ b/lib/stitch_fix/log_weasel/version.rb
@@ -1,5 +1,5 @@
 module StitchFix
   module LogWeasel
-    VERSION = '1.1.0.rc2'
+    VERSION = '1.1.0.rc3'
   end
 end

--- a/lib/stitch_fix/log_weasel/version.rb
+++ b/lib/stitch_fix/log_weasel/version.rb
@@ -1,5 +1,5 @@
 module StitchFix
   module LogWeasel
-    VERSION = '1.0.1'
+    VERSION = '1.1.0.rc1'
   end
 end

--- a/lib/stitch_fix/log_weasel/version.rb
+++ b/lib/stitch_fix/log_weasel/version.rb
@@ -1,5 +1,5 @@
 module StitchFix
   module LogWeasel
-    VERSION = '1.1.0.rc5'
+    VERSION = '1.1.0.rc6'
   end
 end

--- a/lib/stitch_fix/log_weasel/version.rb
+++ b/lib/stitch_fix/log_weasel/version.rb
@@ -1,5 +1,5 @@
 module StitchFix
   module LogWeasel
-    VERSION = '1.1.0.rc4'
+    VERSION = '1.1.0.rc5'
   end
 end

--- a/lib/stitch_fix/log_weasel/version.rb
+++ b/lib/stitch_fix/log_weasel/version.rb
@@ -1,5 +1,5 @@
 module StitchFix
   module LogWeasel
-    VERSION = '1.1.0.rc6'
+    VERSION = '1.1.0.rc7'
   end
 end

--- a/spec/log_weasel/log_weasel_spec.rb
+++ b/spec/log_weasel/log_weasel_spec.rb
@@ -1,4 +1,5 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require 'pwwka'
 require 'resque'
 require 'stitch_fix/log_weasel'
 
@@ -10,6 +11,13 @@ describe StitchFix::LogWeasel do
         config.key = "KEY"
       end
       expect(StitchFix::LogWeasel.config.key).to eq "KEY"
+    end
+
+    it "initializes Log Weasel decorators for defined libraries" do
+      expect(StitchFix::LogWeasel::Pwwka).to receive(:initialize!)
+      expect(StitchFix::LogWeasel::Resque).to receive(:initialize!)
+      expect(StitchFix::LogWeasel::ResqueScheduler).to receive(:initialize!)
+      StitchFix::LogWeasel.configure {}
     end
   end
 

--- a/spec/log_weasel/pwwka_spec.rb
+++ b/spec/log_weasel/pwwka_spec.rb
@@ -23,8 +23,42 @@ describe StitchFix::LogWeasel::Pwwka do
     pwwka_client.logf("Transmitting message %{routing_key} -> %{payload}", {foo: "bar"})
   end
 
+  describe ".enhance_message_handler" do
+    let(:delivery_info) { {:exchange=>"stitchfix-topics-development", :routing_key=>"sf.hello.event"} }
+    let(:properties) { {:content_type=>"application/json; version=1", :correlation_id=>"HELLBLAZER-12345"} }
+    let(:payload) { {} }
+
+    before(:all) { StitchFix::LogWeasel::Pwwka.enhance_message_handler(FakeHandler) }
+
+    it "calls handle_without_log_weasel" do
+      expect(FakeHandler).to receive(:handle_without_log_weasel)
+      FakeHandler.handle!(delivery_info, properties, payload)
+    end
+
+    context "when correlation_id is set in the message headers" do
+      it "sets Log Weasel Transaction ID to it" do
+        expect(StitchFix::LogWeasel::Transaction).to receive(:id=).with("HELLBLAZER-12345")
+        FakeHandler.handle!(delivery_info, properties, payload)
+      end
+    end
+
+    context "when correlation_id is not present" do
+      let(:properties) { {:content_type=>"application/json; version=1"} }
+      it "does not set the Log Weasel Transaction ID" do
+        expect(StitchFix::LogWeasel::Transaction).to_not receive(:id=)
+        FakeHandler.handle!(delivery_info, properties, payload)
+      end
+    end
+  end
+
 end
 
 class MockPwwkaTransmitter
   extend Pwwka::Logging
+end
+
+class FakeHandler
+  def self.handle!(delivery_info, properties, payload)
+    # do nothing
+  end
 end

--- a/spec/log_weasel/resque_scheduler_spec.rb
+++ b/spec/log_weasel/resque_scheduler_spec.rb
@@ -4,6 +4,9 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 describe StitchFix::LogWeasel::ResqueScheduler do
 
   describe "Env" do
+    before do
+      ::Resque::Scheduler::Env.send(:include, StitchFix::LogWeasel::ResqueScheduler::Env)
+    end
     describe "#setup" do
       it "instruments resque-scheduler with Log Weasel" do
         expect(StitchFix::LogWeasel).to receive(:configure)
@@ -14,6 +17,7 @@ describe StitchFix::LogWeasel::ResqueScheduler do
 
   describe "DelayingExtensions" do
     before do
+      ::Resque::Scheduler::DelayingExtensions.send(:include, StitchFix::LogWeasel::ResqueScheduler::DelayingExtensions)
       expect(StitchFix::LogWeasel::Transaction).to receive(:id).and_return("12345")
     end
 

--- a/spec/log_weasel/resque_scheduler_spec.rb
+++ b/spec/log_weasel/resque_scheduler_spec.rb
@@ -1,0 +1,35 @@
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+
+describe StitchFix::LogWeasel::ResqueScheduler do
+
+  describe "Env" do
+    describe "#setup" do
+      it "instruments resque-scheduler with Log Weasel" do
+        expect(StitchFix::LogWeasel).to receive(:configure)
+        Resque::Scheduler::Env.new({}).setup
+      end
+    end
+  end
+
+  describe "DelayingExtensions" do
+    before do
+      expect(StitchFix::LogWeasel::Transaction).to receive(:id).and_return("12345")
+    end
+
+    describe "#job_to_hash_with_queue_and_lid" do
+      context "given queue, klass, and args" do
+        let(:queue) { "queue" }
+        let(:klass) { "SomeJob" }
+        let(:args) { ["hello"] }
+
+        it "adds the Log Weasel transaction ID to args" do
+          result = Resque.job_to_hash_with_queue(queue, klass, args)
+          expect(result[:queue]).to eq(queue)
+          expect(result[:class]).to eq(klass)
+          expect(result[:args]).to include({"log_weasel_id"=>"12345"})
+        end
+      end
+    end
+  end
+end

--- a/spec/log_weasel/resque_scheduler_spec.rb
+++ b/spec/log_weasel/resque_scheduler_spec.rb
@@ -30,6 +30,23 @@ describe StitchFix::LogWeasel::ResqueScheduler do
           Resque::Scheduler.enqueue(config)
           expect(config["args"]).to eq(["Hello from HelloController"])
         end
+
+        context "when the value of log_weasel_id is null" do
+          let(:config) do
+            {"class"=>"EchoJob", "args"=>["Hello from HelloController", {"log_weasel_id" => nil}]}
+          end
+
+          it "sets the current Transaction ID to it" do
+            expect(StitchFix::LogWeasel::Transaction).to receive(:id=).with(nil)
+            Resque::Scheduler.enqueue(config)
+          end
+
+          it "removes it" do
+            expect(config["args"]).to eq(["Hello from HelloController", {"log_weasel_id" => nil}])
+            Resque::Scheduler.enqueue(config)
+            expect(config["args"]).to eq(["Hello from HelloController"])
+          end
+        end
       end
 
       context "without a log_weasel_id" do

--- a/spec/log_weasel/resque_scheduler_spec.rb
+++ b/spec/log_weasel/resque_scheduler_spec.rb
@@ -123,6 +123,19 @@ describe StitchFix::LogWeasel::ResqueScheduler do
             expect(result[:class]).to eq(klass)
             expect(result[:args]).to include({"log_weasel_id"=>"12345"})
           end
+
+          context "when disable_delayed_job_tracing is true" do
+            before do
+              StitchFix::LogWeasel.config.disable_delayed_job_tracing = true
+            end
+
+            it "does not add the Log Weasel transaction ID to args" do
+              result = Resque.job_to_hash_with_queue(queue, klass, args)
+              expect(result[:queue]).to eq(queue)
+              expect(result[:class]).to eq(klass)
+              expect(result[:args]).not_to include({"log_weasel_id"=>"12345"})
+            end
+          end
         end
       end
     end

--- a/spec/log_weasel/resque_scheduler_spec.rb
+++ b/spec/log_weasel/resque_scheduler_spec.rb
@@ -5,7 +5,12 @@ describe StitchFix::LogWeasel::ResqueScheduler do
 
   describe ".enqueue" do
     let(:config) do
-      {"class"=>"EchoJob", "args"=>["delayed hello from HelloController", {"log_weasel_id"=>"FOO-WEB-1234"}]}
+      {"class"=>"EchoJob", "args"=>["Hello from HelloController", {"log_weasel_id"=>"FOO-WEB-1234"}]}
+    end
+
+    before do
+      # so jobs aren't enqueued
+      expect(Resque::Job).to receive(:create).and_return(true)
     end
 
     it "calls setup_log_weasel_transaction_id" do
@@ -21,27 +26,27 @@ describe StitchFix::LogWeasel::ResqueScheduler do
         end
 
         it "removes it" do
-          expect(config["args"]).to eq(["delayed hello from HelloController", {"log_weasel_id" => "FOO-WEB-1234"}])
+          expect(config["args"]).to eq(["Hello from HelloController", {"log_weasel_id" => "FOO-WEB-1234"}])
           Resque::Scheduler.enqueue(config)
-          expect(config["args"]).to eq(["delayed hello from HelloController"])
+          expect(config["args"]).to eq(["Hello from HelloController"])
         end
       end
 
       context "without a log_weasel_id" do
         let(:config) do
-          {"class" => "EchoJob", "args" => ["delayed hello from HelloController"]}
+          {"class" => "EchoJob", "args" => ["Hello from HelloController"]}
         end
 
         it "doesn't modify args" do
           Resque::Scheduler.enqueue(config)
-          expect(config["args"]).to eq(["delayed hello from HelloController"])
+          expect(config["args"]).to eq(["Hello from HelloController"])
         end
       end
     end
 
     context "when args is not an Array" do
       let(:config) do
-        {"class" => "EchoJob", "args" => "delayed hello from HelloController"}
+        {"class" => "EchoJob", "args" => "Hello from HelloController"}
       end
 
       it "sets the current Transaction ID to nil" do
@@ -51,7 +56,7 @@ describe StitchFix::LogWeasel::ResqueScheduler do
 
       it "doesn't modify args" do
         Resque::Scheduler.enqueue(config)
-        expect(config["args"]).to eq("delayed hello from HelloController")
+        expect(config["args"]).to eq("Hello from HelloController")
       end
     end
   end

--- a/spec/log_weasel/resque_scheduler_spec.rb
+++ b/spec/log_weasel/resque_scheduler_spec.rb
@@ -62,10 +62,6 @@ describe StitchFix::LogWeasel::ResqueScheduler do
   end
 
   describe "Env" do
-    before(:all) do
-      ::Resque::Scheduler::Env.send(:include, StitchFix::LogWeasel::ResqueScheduler::Env)
-    end
-
     describe "#setup" do
       it "calls setup_without_log_weasel" do
         expect_any_instance_of(Resque::Scheduler::Env).to receive(:setup_without_log_weasel)
@@ -81,7 +77,6 @@ describe StitchFix::LogWeasel::ResqueScheduler do
 
   describe "DelayingExtensions" do
     before do
-      ::Resque::Scheduler::DelayingExtensions.send(:include, StitchFix::LogWeasel::ResqueScheduler::DelayingExtensions)
       expect(StitchFix::LogWeasel::Transaction).to receive(:id).and_return("12345")
     end
 

--- a/spec/log_weasel/resque_scheduler_spec.rb
+++ b/spec/log_weasel/resque_scheduler_spec.rb
@@ -62,10 +62,16 @@ describe StitchFix::LogWeasel::ResqueScheduler do
   end
 
   describe "Env" do
-    before do
+    before(:all) do
       ::Resque::Scheduler::Env.send(:include, StitchFix::LogWeasel::ResqueScheduler::Env)
     end
+
     describe "#setup" do
+      it "calls setup_without_log_weasel" do
+        expect_any_instance_of(Resque::Scheduler::Env).to receive(:setup_without_log_weasel)
+        Resque::Scheduler::Env.new({}).setup
+      end
+
       it "instruments resque-scheduler with Log Weasel" do
         expect(StitchFix::LogWeasel).to receive(:configure)
         Resque::Scheduler::Env.new({}).setup

--- a/spec/log_weasel/resque_spec.rb
+++ b/spec/log_weasel/resque_spec.rb
@@ -3,10 +3,6 @@ require 'resque'
 
 describe StitchFix::LogWeasel::Resque do
 
-  before do
-    StitchFix::LogWeasel.configure { |config| config.key = "FOO" }
-  end
-  
   after do
     StitchFix::LogWeasel::Transaction.destroy
   end
@@ -16,7 +12,7 @@ describe StitchFix::LogWeasel::Resque do
     expect(Resque).to receive(:encode) do |item|
       expect(item['context']).to_not be_nil
       expect(item['context']).to have_key('log_weasel_id')
-      expect(item['context']['log_weasel_id']).to match(/^FOO-RESQUE/)
+      expect(item['context']['log_weasel_id']).to match(/^COMBUSTION-RESQUE/)
     end
     Resque.push('queue', {'args' => [1]})
   end

--- a/spec/log_weasel/resque_spec.rb
+++ b/spec/log_weasel/resque_spec.rb
@@ -40,4 +40,46 @@ describe StitchFix::LogWeasel::Resque do
       end
     end
   end
+
+  describe ".before_push" do
+    context "when a log_weasel_id is present in the job args" do
+      let(:item) { {args: ["foo", {"log_weasel_id" => "blah"}]}}
+
+      it "sets the LogWeasel::Transaction.id" do
+        expect(StitchFix::LogWeasel::Transaction).to receive(:id=).with("blah")
+        StitchFix::LogWeasel::Resque::Callbacks.before_push nil, item, "KEY"
+      end
+
+      it "removes it and sets context" do
+        StitchFix::LogWeasel::Resque::Callbacks.before_push nil, item, "KEY"
+        expect(item[:args]).to eq(["foo"])
+        expect(item["context"].keys).to include("log_weasel_id")
+      end
+    end
+
+    context "when a log_weasel_id key only is present in the job args" do
+      let(:item) { {args: ["foo", {"log_weasel_id" => nil}]}}
+
+      it "sets the LogWeasel::Transaction.id" do
+        expect(StitchFix::LogWeasel::Transaction).to receive(:id=).with(nil)
+        StitchFix::LogWeasel::Resque::Callbacks.before_push nil, item, "KEY"
+      end
+
+      it "removes it and sets context" do
+        StitchFix::LogWeasel::Resque::Callbacks.before_push nil, item, "KEY"
+        expect(item[:args]).to eq(["foo"])
+        expect(item["context"].keys).to include("log_weasel_id")
+      end
+    end
+
+    context "when a log_weasel_id is NOT present in the job args" do
+      let(:item) { {args: ["foo"]}}
+
+      it "only sets the context" do
+        StitchFix::LogWeasel::Resque::Callbacks.before_push nil, item, "KEY"
+        expect(item[:args]).to eq(["foo"])
+        expect(item["context"].keys).to include("log_weasel_id")
+      end
+    end
+  end
 end

--- a/stitchfix-log_weasel.gemspec
+++ b/stitchfix-log_weasel.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency('pwwka')
   s.add_development_dependency('rake')
   s.add_development_dependency('resque')
+  s.add_development_dependency('resque-scheduler')
+  s.add_development_dependency('resque-status')
   s.add_development_dependency('rspec')
   s.add_development_dependency('rspec_junit_formatter')
   s.add_development_dependency('stitchfix-y')

--- a/stitchfix-log_weasel.gemspec
+++ b/stitchfix-log_weasel.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake')
   s.add_development_dependency('resque')
   s.add_development_dependency('resque-scheduler')
-  s.add_development_dependency('resque-status')
   s.add_development_dependency('rspec')
   s.add_development_dependency('rspec_junit_formatter')
   s.add_development_dependency('stitchfix-y')


### PR DESCRIPTION
## Problem
Nicola filed [an issue](https://github.com/stitchfix/log_weasel/issues/3) against Log Weasel where she was seeing static Log Weasel transaction IDs across multiple requests - which shouldn't happen. Each unit of work should be given a unique UUID, whether the work begins with a web request, API request, or a Resque job (scheduled or delayed). Additionally, Pwwka message handlers need to be able to pass along this UUID to processes kicked off in the handler (like a Resque job) so the transaction ID can be threaded through to all parties involved in processing the unit of work. 

## Findings
I did a holistic reevaluation of Log Weasel, and found several issues:
1) LW transaction IDs for delayed Resque jobs (handled by Resque Scheduler) were not being properly set/managed. 
2) There was no _real_ LW support for Pwwka to pass along the LW transaction ID to processes kicked off in the message handler.
3) There was some inconsistency in the way the LW ID was being managed for Resque jobs.

## Solution
I addressed all of my findings (above). ~Still working on getting supporting tests written/passing, but wanted to get some early feedback on this.~ There is quite a bit of Ruby "magic" here, so ideas on how to make it less magical would be welcomed.

UPDATE (7/27/17): Specs are complete. A couple of late-breaking bugs were identified and fixed. And a new configuration option: `disable_delayed_job_tracing` has been added. This allows a consumer of this gem to turn off the LW functionality of appending a log_weasel_id parameter to a delayed Resque job's payload.
