### PR TITLE
Add guard to requires.

### DIFF
--- a/lib/stitch_fix/log_weasel.rb
+++ b/lib/stitch_fix/log_weasel.rb
@@ -3,9 +3,7 @@ require 'stitch_fix/log_weasel/logger'
 require 'stitch_fix/log_weasel/airbrake'
 require 'stitch_fix/log_weasel/middleware'
 require 'stitch_fix/log_weasel/resque'
-require 'stitch_fix/log_weasel/resque_scheduler'
 require 'stitch_fix/log_weasel/pwwka'
-require 'stitch_fix/log_weasel/monkey_patches'
 require 'stitch_fix/log_weasel/railtie' if defined? ::Rails::Railtie
 
 module StitchFix
@@ -41,6 +39,9 @@ module StitchFix
       end
 
       if defined? ::Resque::Scheduler
+        require 'stitch_fix/log_weasel/resque_scheduler'
+        require 'stitch_fix/log_weasel/monkey_patches'
+
         StitchFix::LogWeasel::ResqueScheduler.initialize!
       end
     end

--- a/spec/log_weasel/resque_scheduler_spec.rb
+++ b/spec/log_weasel/resque_scheduler_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-
+require 'stitch_fix/log_weasel/resque_scheduler'
+require 'stitch_fix/log_weasel/monkey_patches'
 
 describe StitchFix::LogWeasel::ResqueScheduler do
 


### PR DESCRIPTION
**Problem**

Some of our apps do not use resque_scheduler, and when log weasel is added to one of these projects, a `LoadError` is caused due to how log weasel requires resque_scheduler dependencies when it is initialized.

**Solution**

Only require resque_scheduler code in log weasel if resque scheduler is defined.

```
LoadError: cannot load such file -- resque/scheduler/env
/home/ubuntu/mobile-service/vendor/bundle/ruby/2.3.0/gems/stitchfix-log_weasel-1.1.0/lib/stitch_fix/log_weasel/resque_scheduler.rb:1:in `require'
/home/ubuntu/mobile-service/vendor/bundle/ruby/2.3.0/gems/stitchfix-log_weasel-1.1.0/lib/stitch_fix/log_weasel/resque_scheduler.rb:1:in `<top (required)>'
/home/ubuntu/mobile-service/vendor/bundle/ruby/2.3.0/gems/stitchfix-log_weasel-1.1.0/lib/stitch_fix/log_weasel.rb:6:in `require'
/home/ubuntu/mobile-service/vendor/bundle/ruby/2.3.0/gems/stitchfix-log_weasel-1.1.0/lib/stitch_fix/log_weasel.rb:6:in `<top (required)>'

```