### PR TITLE
Include LoggerSilence for apps running Rails >= 5.

### DIFF
--- a/lib/stitch_fix/log_weasel/logger.rb
+++ b/lib/stitch_fix/log_weasel/logger.rb
@@ -2,6 +2,15 @@ require 'logger'
 
 module StitchFix
   class LogWeasel::Logger < ::Logger
+    if defined?(Rails)
+      # include LoggerSilence for Rails versions >= 5
+      requirement = Gem::Requirement.new('>= 5.0.0')
+      version = Gem.loaded_specs['rails'].version
+      if requirement.satisfied_by?(version)
+        include LoggerSilence
+      end
+    end
+
     def add(severity, message = nil, progname = nil, &block)
       super(severity, "[#{DateTime.now.strftime('%Y-%m-%d %H:%M:%S')}] #{LogWeasel::Transaction.id} #$$ #{format_severity(severity)} #{message}", progname, &block)
     end

--- a/lib/stitch_fix/log_weasel/logger.rb
+++ b/lib/stitch_fix/log_weasel/logger.rb
@@ -3,12 +3,7 @@ require 'logger'
 module StitchFix
   class LogWeasel::Logger < ::Logger
     if defined?(Rails)
-      # include LoggerSilence for Rails versions >= 5
-      requirement = Gem::Requirement.new('>= 5.0.0')
-      version = Gem.loaded_specs['rails'].version
-      if requirement.satisfied_by?(version)
-        include LoggerSilence
-      end
+      include LoggerSilence
     end
 
     def add(severity, message = nil, progname = nil, &block)

--- a/lib/stitch_fix/log_weasel/logger.rb
+++ b/lib/stitch_fix/log_weasel/logger.rb
@@ -2,9 +2,7 @@ require 'logger'
 
 module StitchFix
   class LogWeasel::Logger < ::Logger
-    if defined?(Rails)
-      include LoggerSilence
-    end
+    include LoggerSilence if defined?(LoggerSilence)
 
     def add(severity, message = nil, progname = nil, &block)
       super(severity, "[#{DateTime.now.strftime('%Y-%m-%d %H:%M:%S')}] #{LogWeasel::Transaction.id} #$$ #{format_severity(severity)} #{message}", progname, &block)

--- a/lib/stitch_fix/log_weasel/version.rb
+++ b/lib/stitch_fix/log_weasel/version.rb
@@ -1,5 +1,5 @@
 module StitchFix
   module LogWeasel
-    VERSION = '1.2.1.rc1'
+    VERSION = '1.2.0.rc1'
   end
 end

--- a/lib/stitch_fix/log_weasel/version.rb
+++ b/lib/stitch_fix/log_weasel/version.rb
@@ -1,5 +1,5 @@
 module StitchFix
   module LogWeasel
-    VERSION = '1.2.0.rc1'
+    VERSION = '1.1.2'
   end
 end

--- a/lib/stitch_fix/log_weasel/version.rb
+++ b/lib/stitch_fix/log_weasel/version.rb
@@ -1,5 +1,5 @@
 module StitchFix
   module LogWeasel
-    VERSION = '1.1.1'
+    VERSION = '1.2.1.rc1'
   end
 end

--- a/stitchfix-log_weasel.gemspec
+++ b/stitchfix-log_weasel.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('logger')
   s.add_development_dependency('mocha')
   s.add_development_dependency('pwwka')
+  s.add_development_dependency('rails')
   s.add_development_dependency('rake')
   s.add_development_dependency('resque')
   s.add_development_dependency('resque-scheduler')

--- a/stitchfix-log_weasel.gemspec
+++ b/stitchfix-log_weasel.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('logger')
   s.add_development_dependency('mocha')
   s.add_development_dependency('pwwka')
-  s.add_development_dependency('rails')
   s.add_development_dependency('rake')
   s.add_development_dependency('resque')
   s.add_development_dependency('resque-scheduler')


### PR DESCRIPTION
This addresses Issue #6. Copied here for convenience:

## Problem
In Rails 5 they moved the #silence method to a concern. This can occasionally break things when other libraries expect it to be there (see stitchfix/playback#38).

## Solution
Detect rails version and include LoggerSilence when applicable. This prevents downstream apps that use LogWeasel from having to care about this.