### PR TITLE
ro/rlo-28 update rails middlware key

### DIFF
--- a/lib/stitch_fix/log_weasel/middleware.rb
+++ b/lib/stitch_fix/log_weasel/middleware.rb
@@ -14,9 +14,7 @@ module StitchFix
     # Future: Maybe add X-Amzn-Trace-Id request header for tracing through load balancer
     # (http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html)
     def call(env)
-      x_correlation_id = env.fetch(REQUEST_ID_KEY,
-                                   env.fetch(CORRELATION_ID_KEY,
-                                             nil))
+      x_correlation_id = env.fetch(REQUEST_ID_KEY, nil) || env.fetch(CORRELATION_ID_KEY, nil)
 
       if x_correlation_id
         LogWeasel::Transaction.id = x_correlation_id

--- a/lib/stitch_fix/log_weasel/middleware.rb
+++ b/lib/stitch_fix/log_weasel/middleware.rb
@@ -1,6 +1,10 @@
+# frozen_string_literal: true
+
 module StitchFix
   class LogWeasel::Middleware
     KEY_HEADER = 'X_LOGWEASEL_KEY'
+    CORRELATION_ID_KEY = "HTTP_X_CORRELATION_ID"
+    REQUEST_ID_KEY = "HTTP_X_REQUEST_ID"
 
     def initialize(app, options = {})
       @app = app
@@ -10,14 +14,17 @@ module StitchFix
     # Future: Maybe add X-Amzn-Trace-Id request header for tracing through load balancer
     # (http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html)
     def call(env)
-      x_request_id = env.fetch("HTTP_X_REQUEST_ID", nil)
+      x_correlation_id = env.fetch(REQUEST_ID_KEY,
+                                   env.fetch(CORRELATION_ID_KEY,
+                                             nil))
 
-      if x_request_id
-        LogWeasel::Transaction.id = x_request_id
+      if x_correlation_id
+        LogWeasel::Transaction.id = x_correlation_id
       else
         log_weasel_key = env.fetch("HTTP_#{KEY_HEADER}", @key)
         LogWeasel::Transaction.create(log_weasel_key)
-        env["HTTP_X_REQUEST_ID"] = LogWeasel::Transaction.id
+        env[CORRELATION_ID_KEY] = LogWeasel::Transaction.id
+        env[REQUEST_ID_KEY] = LogWeasel::Transaction.id
       end
       @app.call(env)
     ensure

--- a/spec/log_weasel/middleware_spec.rb
+++ b/spec/log_weasel/middleware_spec.rb
@@ -33,7 +33,7 @@ describe StitchFix::LogWeasel::Middleware do
         end
       end
 
-      context "when both REQUEST_ID_KEY and CORRELATION_ID_KEY headers set present" do
+      context "when both REQUEST_ID_KEY and CORRELATION_ID_KEY headers are present" do
         let(:env) {
           {StitchFix::LogWeasel::Middleware::CORRELATION_ID_KEY => "1234",
            StitchFix::LogWeasel::Middleware::REQUEST_ID_KEY => "5678"}
@@ -45,7 +45,7 @@ describe StitchFix::LogWeasel::Middleware do
         end
       end
 
-      context "when an StitchFix::LogWeasel::Middleware::CORRELATION_ID_KEY header is NOT present" do
+      context "when neither CORRELATION_ID_KEY nor REQUEST_ID_KEY header is present" do
         let(:env) { {} }
 
         before do


### PR DESCRIPTION
# Problem

Update the key used for correlation ids
    
Per decision in
https://docs.google.com/document/d/1wPn7M2HE2ghZJutWaMbctNcSroc-9r1FFdEUriYlxDc/edit
we are going to use `X-CORRELATION-ID` rather than `X-REQUEST-ID`. This
makes that change.

As an intermediate step we will use the parallel change pattern to allow
both until dependencies are all updated to use X-Correllation-ID we will
contract the headers.

See also: https://github.com/stitchfix/api_client/pull/78    
Refs: https://stitchfix.atlassian.net/browse/RLO-28


# Solution

Update `log_weasel`  to reflect that decision. We will remove the use of `X-Request-ID` once all the dependents have been updated.

[Google Doc](https://docs.google.com/document/d/1wPn7M2HE2ghZJutWaMbctNcSroc-9r1FFdEUriYlxDc/edit)
[Jira ticket](https://stitchfix.atlassian.net/browse/RLO-28)
