### PR TITLE
Update `log_weasel` to use ULIDs for IDs

### DIFF
--- a/lib/stitch_fix/log_weasel/transaction.rb
+++ b/lib/stitch_fix/log_weasel/transaction.rb
@@ -1,15 +1,11 @@
-begin
-  require 'securerandom'
-rescue
-  require 'active_support/secure_random'
-end
+require "ulid"
 
 module StitchFix
   module LogWeasel
     module Transaction
 
       def self.create(key = nil)
-        Thread.current[:log_weasel_id] = "#{key ? "#{key}-" : ""}#{SecureRandom.hex(10)}"
+        Thread.current[:log_weasel_id] = "#{ULID.generate}#{key ? "-#{key}" : ""}"
       end
 
       def self.destroy

--- a/spec/log_weasel/resque_spec.rb
+++ b/spec/log_weasel/resque_spec.rb
@@ -12,7 +12,7 @@ describe StitchFix::LogWeasel::Resque do
     expect(Resque).to receive(:encode) do |item|
       expect(item['context']).to_not be_nil
       expect(item['context']).to have_key('log_weasel_id')
-      expect(item['context']['log_weasel_id']).to match(/^COMBUSTION-RESQUE/)
+      expect(item['context']['log_weasel_id']).to match(/-COMBUSTION-RESQUE$/)
     end
     Resque.push('queue', {'args' => [1]})
   end

--- a/spec/log_weasel/transaction_spec.rb
+++ b/spec/log_weasel/transaction_spec.rb
@@ -23,19 +23,20 @@ describe StitchFix::LogWeasel::Transaction do
   end
 
   describe ".create" do
-    before do
-      allow(SecureRandom).to receive(:hex).and_return("94b2")
-    end
-
-    it "creates a transaction id with no key" do
+    let(:regex) { /(?:[A-Z2-7]{8})*(?:[A-Z2-7]{2}={6}|[A-Z2-7]{4}={4}|[A-Z2-7]{5}={3}|[A-Z2-7]{7}=)?/ }
+    it "creates a transaction id with no key prefix" do
       id = StitchFix::LogWeasel::Transaction.create
-      expect(id).to eq '94b2'
+      expect(id).to match(regex)
+      expect(id.size).to eq(26)
     end
 
-    it "creates a transaction id with a key" do
-      id = StitchFix::LogWeasel::Transaction.create "KEY"
-      expect(id).to eq "KEY-94b2"
-      expect(StitchFix::LogWeasel::Transaction.id).to eq id
+    it "creates a transaction id with a key prefix" do
+      key = "KEY"
+      id = StitchFix::LogWeasel::Transaction.create key
+      expect(id).to match(/-KEY/)
+      expect(id).to match(regex)
+      # adds one here to account for hyphen
+      expect(id.size).to eq(26 + 1 + key.size)
     end
 
   end

--- a/spec/log_weasel/transaction_spec.rb
+++ b/spec/log_weasel/transaction_spec.rb
@@ -30,7 +30,7 @@ describe StitchFix::LogWeasel::Transaction do
       expect(id.size).to eq(26)
     end
 
-    it "creates a transaction id with a key prefix" do
+    it "creates a transaction id with a key suffix" do
       key = "KEY"
       id = StitchFix::LogWeasel::Transaction.create key
       expect(id).to match(/-KEY/)

--- a/stitchfix-log_weasel.gemspec
+++ b/stitchfix-log_weasel.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('combustion')
 
   s.add_dependency('activesupport')
+  s.add_dependency('ulid')
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
## Problem

Correlation IDs aren't lexicographically meaningful.

## Solution

We want to Correlation IDs to be sortable by time. So we moved the app
id to be a suffix and updated the ID generator to use ULIDs which are
48 bits of timestamp and 80 bits of random.

Refs: https://stitchfix.atlassian.net/browse/RLO-28
Co-Authored-By: Adam Strickland <adam.strickland@stitchfix.com>

[Google Doc](https://docs.google.com/document/d/1wPn7M2HE2ghZJutWaMbctNcSroc-9r1FFdEUriYlxDc/edit)
[Jira ticket](https://stitchfix.atlassian.net/browse/RLO-28)

## Checklist

### Before Merging

- [ ] If there is an RC on this branch, revert the version change in `version.rb`

### After Merging

See the [gem release process](https://github.com/stitchfix/eng-wiki/blob/master/technical-topics/updating-gem-versions.md) for a detailed list, but the gist of it is:

- [ ] Fetch `master` locally and run the applicable `rake version:*` task **on `master`** to bump the version
- [ ] Run `rake release` **on `master`** to release the new version on Gemfury
- [ ] Add [release notes](https://github.com/stitchfix/log_weasel/releases) - **this is very important in helping other engineers understand what changed in the new version**
