### PR TITLE
Add link to Stitch Fix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Use bundler to install it:
 bundle install
 </pre>
 
+## Stitch Fix
+See [this setup guide](https://github.com/stitchfix/eng-wiki/blob/master/technical-topics/log-weasel-configuration.md) for how to configure Log Weasel for Rails applications at Stitch Fix.
+
 ## Rails
 
 For Rails projects, we provide a Railtie that automatically configures and loads Log Weasel.


### PR DESCRIPTION
## Problem

The logger configuration in Rails apps at Stitch Fix is different than vanilla Rails. The setup outlined in the README therefore does not apply to Stitch Fix Rails apps.

## Solution

Add a link to the documentation on the eng-wiki on how to configure Log Weasel in Stitch Fix Rails apps.

«Brief description of how you solved the problem»

## Checklist

### Before Merging

- [ ] If there is an RC on this branch, revert the version change in `version.rb`

### After Merging

See the [gem release process](https://github.com/stitchfix/eng-wiki/blob/master/technical-topics/updating-gem-versions.md) for a detailed list, but the gist of it is:

- [ ] Fetch `master` locally and run the applicable `rake version:*` task **on `master`** to bump the version
- [ ] Run `rake release` **on `master`** to release the new version on Gemfury
- [ ] Add [release notes](https://github.com/stitchfix/log_weasel/releases) - **this is very important in helping other engineers understand what changed in the new version**
