### PR TITLE
prefer non-deprecated module if available

### DIFF
--- a/lib/stitch_fix/log_weasel/logger.rb
+++ b/lib/stitch_fix/log_weasel/logger.rb
@@ -2,7 +2,11 @@ require 'logger'
 
 module StitchFix
   class LogWeasel::Logger < ::Logger
-    include LoggerSilence if defined?(LoggerSilence)
+    if defined?(ActiveSupport::LoggerSilence)
+      include(ActiveSupport::LoggerSilence)
+    elsif defined?(LoggerSilence)
+      include(LoggerSilence)
+    end
 
     def add(severity, message = nil, progname = nil, &block)
       super(severity, "[#{DateTime.now.strftime('%Y-%m-%d %H:%M:%S')}] #{LogWeasel::Transaction.id} #$$ #{format_severity(severity)} #{message}", progname, &block)


### PR DESCRIPTION
## Problem

When upgrading to Rails 6, the following deprecation warning is emitted: 

```
DEPRECATION WARNING: Including LoggerSilence is deprecated and will be removed in Rails 6.1. Please use `ActiveSupport::LoggerSilence` instead (called from <top (required)> at /Users/srinivasrao/Documents/stitchfix/question-set-service/config/application.rb:22)
```

## Solution

attempt to include `ActiveSupport::LoggerSilence` first if available, while still falling back to `LoggerSilence` for backwards compatibility. 
