### PR TITLE
Mute puts by adding debug configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,6 @@ customize the formatting of your logger to include <code>LogWeasel::Transaction.
 <pre>
 YourApp::Application.configure do
   config.log_weasel.key = 'YOUR_APP'    # Optional. Defaults to Rails application name.
-
-  logger = StitchFix::LogWeasel::Logger.new "#{Rails.root}/log/#{Rails.env}.log"
-  config.logger                   = logger
-  config.action_controller.logger = logger
-  config.active_record.logger     = logger
 end
 </pre>
 
@@ -52,6 +47,7 @@ Load and configure Log Weasel with:
 LogWeasel.configure do |config|
   config.key = "YOUR_APP"
   config.disable_delayed_job_tracing = false
+  config.debug = !Rails.env.production?
 end
 </pre>
 
@@ -62,6 +58,9 @@ useful in an environment where a unit of work may span multiple applications.
 <code>config.disable_delayed_job_tracing</code> (default is `false`)  
 A boolean that disables Log Weasel appending a `log_weasel_id` parameter in 
 the payloads of delayed Resque jobs. The default is `false`. 
+
+<code>config.debug</code> (default is `false`)  
+A boolean that enables some additional debug logging. The default is `false`. 
  
 Setting these configuration options are optional, but you must call <code>LogWeasel.configure</code>.
 

--- a/lib/stitch_fix/log_weasel.rb
+++ b/lib/stitch_fix/log_weasel.rb
@@ -9,7 +9,7 @@ require 'stitch_fix/log_weasel/railtie' if defined? ::Rails::Railtie
 module StitchFix
   module LogWeasel
     class Config
-      attr_accessor :key, :disable_delayed_job_tracing
+      attr_accessor :key, :disable_delayed_job_tracing, :debug
 
       def disable_delayed_job_tracing?
         @disable_delayed_job_tracing ||

--- a/lib/stitch_fix/log_weasel.rb
+++ b/lib/stitch_fix/log_weasel.rb
@@ -15,6 +15,10 @@ module StitchFix
         @disable_delayed_job_tracing ||
           (defined?(Rails) && Rails.env.test?)
       end
+
+      def debug_logging_enabled?
+        @debug || false
+      end
     end
 
     def self.config

--- a/lib/stitch_fix/log_weasel/monkey_patches.rb
+++ b/lib/stitch_fix/log_weasel/monkey_patches.rb
@@ -13,13 +13,13 @@ module Resque
       if config["args"].is_a?(Array)
         log_weasel_payload = config["args"].detect { |arg| arg.is_a?(Hash) && arg.keys.include?("log_weasel_id") }
         if log_weasel_payload
-          puts "A log_weasel_id was found in the job payload. Setting the current Transaction id to it."
+          puts "A log_weasel_id was found in the job payload. Setting the current Transaction id to it." if StitchFix::LogWeasel.config.debug
           StitchFix::LogWeasel::Transaction.id = log_weasel_payload["log_weasel_id"]
-          puts "Removing the log_weasel_id from the payload."
+          puts "Removing the log_weasel_id from the payload." if StitchFix::LogWeasel.config.debug
           config["args"] = config["args"] - [log_weasel_payload]
         end
       else
-        puts "Initializing log weasel transaction ID"
+        puts "Initializing log weasel transaction ID" if StitchFix::LogWeasel.config.debug
         StitchFix::LogWeasel::Transaction.id = nil
       end
     end

--- a/lib/stitch_fix/log_weasel/monkey_patches.rb
+++ b/lib/stitch_fix/log_weasel/monkey_patches.rb
@@ -13,13 +13,13 @@ module Resque
       if config["args"].is_a?(Array)
         log_weasel_payload = config["args"].detect { |arg| arg.is_a?(Hash) && arg.keys.include?("log_weasel_id") }
         if log_weasel_payload
-          puts "A log_weasel_id was found in the job payload. Setting the current Transaction id to it." if StitchFix::LogWeasel.config.debug
+          puts "A log_weasel_id was found in the job payload. Setting the current Transaction id to it." if StitchFix::LogWeasel.config.debug_logging_enabled?
           StitchFix::LogWeasel::Transaction.id = log_weasel_payload["log_weasel_id"]
-          puts "Removing the log_weasel_id from the payload." if StitchFix::LogWeasel.config.debug
+          puts "Removing the log_weasel_id from the payload." if StitchFix::LogWeasel.config.debug_logging_enabled?
           config["args"] = config["args"] - [log_weasel_payload]
         end
       else
-        puts "Initializing log weasel transaction ID" if StitchFix::LogWeasel.config.debug
+        puts "Initializing log weasel transaction ID" if StitchFix::LogWeasel.config.debug_logging_enabled?
         StitchFix::LogWeasel::Transaction.id = nil
       end
     end

--- a/lib/stitch_fix/log_weasel/resque_scheduler.rb
+++ b/lib/stitch_fix/log_weasel/resque_scheduler.rb
@@ -16,7 +16,7 @@ module StitchFix
     module Env
       # To instrument resque:scheduler rake task with Log Weasel
       def setup_with_log_weasel
-        puts "initializing Log Weasel"
+        puts "initializing Log Weasel" if StitchFix::LogWeasel.config.debug
         key = defined?(::Rails::Railtie) ? StitchFix::LogWeasel::Railtie.app_name.upcase : nil
         key ? "#{key}-RESQUE" : "RESQUE"
         StitchFix::LogWeasel.configure { |config| config.key = key }

--- a/lib/stitch_fix/log_weasel/resque_scheduler.rb
+++ b/lib/stitch_fix/log_weasel/resque_scheduler.rb
@@ -16,7 +16,7 @@ module StitchFix
     module Env
       # To instrument resque:scheduler rake task with Log Weasel
       def setup_with_log_weasel
-        puts "initializing Log Weasel" if StitchFix::LogWeasel.config.debug
+        puts "initializing Log Weasel" if StitchFix::LogWeasel.config.debug_logging_enabled?
         key = defined?(::Rails::Railtie) ? StitchFix::LogWeasel::Railtie.app_name.upcase : nil
         key ? "#{key}-RESQUE" : "RESQUE"
         StitchFix::LogWeasel.configure { |config| config.key = key }

--- a/spec/log_weasel/resque_scheduler_spec.rb
+++ b/spec/log_weasel/resque_scheduler_spec.rb
@@ -56,17 +56,26 @@ describe StitchFix::LogWeasel::ResqueScheduler do
         end
       end
 
-      context "in debug mode" do
-        before do
-          StitchFix::LogWeasel.configure do |config|
-            config.debug = true
+      context "debug mode" do
+        context "when true" do
+          before do
+            StitchFix::LogWeasel.configure do |config|
+              config.debug = true
+            end
+          end
+
+          it "logs" do
+            expect(Resque::Scheduler).to receive(:puts).with("A log_weasel_id was found in the job payload. Setting the current Transaction id to it.")
+            expect(Resque::Scheduler).to receive(:puts).with("Removing the log_weasel_id from the payload.")
+            Resque::Scheduler.enqueue(config)
           end
         end
 
-        it "logs" do
-          expect(Resque::Scheduler).to receive(:puts).with("A log_weasel_id was found in the job payload. Setting the current Transaction id to it.")
-          expect(Resque::Scheduler).to receive(:puts).with("Removing the log_weasel_id from the payload.")
-          Resque::Scheduler.enqueue(config)
+        context "by default" do
+          it "doesn't log" do
+            expect(Resque::Scheduler).not_to receive(:puts)
+            Resque::Scheduler.enqueue(config)
+          end
         end
       end
 
@@ -124,16 +133,25 @@ describe StitchFix::LogWeasel::ResqueScheduler do
         Resque::Scheduler::Env.new({}).setup
       end
 
-      context "in debug mode" do
-        before do
-          StitchFix::LogWeasel.configure do |config|
-            config.debug = true
+      context "debug mode" do
+        context "when true" do
+          before do
+            StitchFix::LogWeasel.configure do |config|
+              config.debug = true
+            end
+          end
+
+          it "logs" do
+            expect_any_instance_of(Resque::Scheduler::Env).to receive(:puts).with("initializing Log Weasel")
+            Resque::Scheduler::Env.new({}).setup
           end
         end
 
-        it "logs in debug mode" do
-          expect_any_instance_of(Resque::Scheduler::Env).to receive(:puts).with("initializing Log Weasel")
-          Resque::Scheduler::Env.new({}).setup
+        context "by default" do
+          it "doesn't log" do
+            expect_any_instance_of(Resque::Scheduler::Env).not_to receive(:puts)
+            Resque::Scheduler::Env.new({}).setup
+          end
         end
       end
     end


### PR DESCRIPTION
## Problem

LogWeasel logging is noisy, as there are some `puts` sprinkled into the codebase "put" there originally for debugging purposes. Extraneous logging increases our logging costs, so let's not log if we don't need to.

![Screen Shot 2019-10-17 at 2 06 44 PM](https://user-images.githubusercontent.com/400730/67047809-e6b14680-f0e7-11e9-9a37-095384f81366.png)

## Solution

Add a `debug` configuration option, and only invoke these `puts` lines when `debug` is configured as truthy.