### PR TITLE
Fix invalid spec setup (passing :active_support to Combustion)

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'combustion'
 require 'stitch_fix/log_weasel'
 
-Combustion.initialize! :active_support
+Combustion.initialize!
 
 require 'rspec'
 


### PR DESCRIPTION
## Problem

After a version upgrade to 1.2.0, Combustion started raising an error on log_weasel deploys:
https://github.com/stitchfix/log_weasel/commit/26a1a07d73737994c67b11e7794b3fa1bdf0d6ed

The reason for this is that we were initializing Combustion with `:active_support`, which was not a valid input (https://github.com/pat/combustion/blob/2cf632bcf6dae1db8a48dc3575c359af7f597ed6/lib/combustion.rb#L16-L29). 

Combustion started raising errors on invalid modules in 1.2.0.

ActiveSupport is always loaded by Combustion, as specified in their README: https://github.com/pat/combustion/tree/2cf632bcf6dae1db8a48dc3575c359af7f597ed6#configuring-which-rails-modules-should-be-loaded

> ActiveSupport and Railties are always loaded, as they're an integral part of Rails.

## Solution
Remove the invalid `:active_support` input.

## Checklist

### Before Merging

- [ ] If there is an RC on this branch, revert the version change in `version.rb`

### After Merging

See the [gem release process](https://github.com/stitchfix/eng-wiki/blob/master/technical-topics/updating-gem-versions.md) for a detailed list, but the gist of it is:

- [ ] Fetch `master` locally and run the applicable `rake version:*` task **on `master`** to bump the version
- [ ] Run `rake release` **on `master`** to release the new version on Gemfury
- [ ] Add [release notes](https://github.com/stitchfix/log_weasel/releases) - **this is very important in helping other engineers understand what changed in the new version**
