### PR TITLE
Adds ability to pull logweasel id from params

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Log Weasel provides Rack middleware to create and destroy a transaction ID for e
 in a any web framework that supports Rack (Rails, Sinatra,...) by using <code>LogWeasel::Middleware</code> in your middleware
 stack.
 
+### Log Weasel ID From Params
+
+The Log Weasel transaction id can also be passed via query string.  While this should not be necessary for common Stitch Fix engineering use cases, you can include a `logweasel_id` key in the query string and set `LOG_WEASEL_FROM_PARAMS` environment variable in your application via `fixops`.  **Note** this will take precedence over the values passed in the HTTP headers the Log Weasel middleware looks at.
+
 ## Resque
 
 When you configure Log Weasel as described above either in Rails or by explicitly calling <code>LogWeasel.configure</code>,

--- a/lib/stitch_fix/log_weasel/middleware.rb
+++ b/lib/stitch_fix/log_weasel/middleware.rb
@@ -5,6 +5,7 @@ module StitchFix
     KEY_HEADER = 'X_LOGWEASEL_KEY'
     CORRELATION_ID_KEY = "HTTP_X_CORRELATION_ID"
     REQUEST_ID_KEY = "HTTP_X_REQUEST_ID"
+    PARAMS_KEY = "logweasel_id"
 
     def initialize(app, options = {})
       @app = app
@@ -14,16 +15,23 @@ module StitchFix
     # Future: Maybe add X-Amzn-Trace-Id request header for tracing through load balancer
     # (http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html)
     def call(env)
+      req = Rack::Request.new(env)
       x_correlation_id = env.fetch(REQUEST_ID_KEY, nil) || env.fetch(CORRELATION_ID_KEY, nil)
+
+      if ENV.fetch('LOGWEASEL_FROM_PARAMS', nil) && req.params[PARAMS_KEY]
+        x_correlation_id = req.params[PARAMS_KEY]
+      end
 
       if x_correlation_id
         LogWeasel::Transaction.id = x_correlation_id
       else
         log_weasel_key = env.fetch("HTTP_#{KEY_HEADER}", @key)
         LogWeasel::Transaction.create(log_weasel_key)
-        env[CORRELATION_ID_KEY] = LogWeasel::Transaction.id
-        env[REQUEST_ID_KEY] = LogWeasel::Transaction.id
       end
+
+      env[CORRELATION_ID_KEY] = LogWeasel::Transaction.id
+      env[REQUEST_ID_KEY] = LogWeasel::Transaction.id
+
       @app.call(env)
     ensure
       LogWeasel::Transaction.destroy

--- a/lib/stitch_fix/log_weasel/middleware.rb
+++ b/lib/stitch_fix/log_weasel/middleware.rb
@@ -38,8 +38,7 @@ module StitchFix
       return unless ENV.fetch('LOG_WEASEL_FROM_PARAMS', nil)
 
       req = Rack::Request.new(env)
-
-      req.params[PARAMS_KEY]
+      req.params.fetch(PARAMS_KEY, nil)
     end
   end
 end

--- a/lib/stitch_fix/log_weasel/version.rb
+++ b/lib/stitch_fix/log_weasel/version.rb
@@ -1,5 +1,5 @@
 module StitchFix
   module LogWeasel
-    VERSION = "1.4.0.RC"
+    VERSION = "1.3.0"
   end
 end

--- a/lib/stitch_fix/log_weasel/version.rb
+++ b/lib/stitch_fix/log_weasel/version.rb
@@ -1,5 +1,5 @@
 module StitchFix
   module LogWeasel
-    VERSION = "1.3.0"
+    VERSION = "1.4.0.RC"
   end
 end

--- a/spec/log_weasel/middleware_spec.rb
+++ b/spec/log_weasel/middleware_spec.rb
@@ -94,6 +94,7 @@ describe StitchFix::LogWeasel::Middleware do
           it "does not set the log weasel id from the params" do
             allow(ENV).to receive(:fetch).with('LOG_WEASEL_FROM_PARAMS', nil).and_return(true)
 
+            # Let's pretend its a header...
             env['HTTP_X_REQUEST_ID'] = 'bar'
 
             expect(StitchFix::LogWeasel::Transaction).to receive(:id=).with("bar")

--- a/spec/log_weasel/middleware_spec.rb
+++ b/spec/log_weasel/middleware_spec.rb
@@ -76,9 +76,27 @@ describe StitchFix::LogWeasel::Middleware do
 
         context "with the environment variable enabled" do
           it "sets LogWeasel::Transation.id to the parameter value" do
-            allow(ENV).to receive(:fetch).with('LOGWEASEL_FROM_PARAMS', nil).and_return(true)
+            allow(ENV).to receive(:fetch).with('LOG_WEASEL_FROM_PARAMS', nil).and_return(true)
 
             expect(StitchFix::LogWeasel::Transaction).to receive(:id=).with("foo")
+
+            StitchFix::LogWeasel::Middleware.new(app).call(env)
+          end
+        end
+      end
+
+      context "when the log weasel id is not included in the params" do
+        let(:env) do
+          Rack::MockRequest.env_for("something", params: { something_else: 'foo' })
+        end
+
+        context "with the environment variable enabled" do
+          it "does not set the log weasel id from the params" do
+            allow(ENV).to receive(:fetch).with('LOG_WEASEL_FROM_PARAMS', nil).and_return(true)
+
+            env['HTTP_X_REQUEST_ID'] = 'bar'
+
+            expect(StitchFix::LogWeasel::Transaction).to receive(:id=).with("bar")
 
             StitchFix::LogWeasel::Middleware.new(app).call(env)
           end

--- a/spec/log_weasel/middleware_spec.rb
+++ b/spec/log_weasel/middleware_spec.rb
@@ -75,12 +75,24 @@ describe StitchFix::LogWeasel::Middleware do
         end
 
         context "with the environment variable enabled" do
-          it "sets LogWeasel::Transation.id to the parameter value" do
+          it "sets LogWeasel::Transation.id to the header value" do
             allow(ENV).to receive(:fetch).with('LOG_WEASEL_FROM_PARAMS', nil).and_return(true)
 
-            expect(StitchFix::LogWeasel::Transaction).to receive(:id=).with("foo")
+            env['HTTP_X_REQUEST_ID'] = 'bar'
+
+            expect(StitchFix::LogWeasel::Transaction).to receive(:id=).with("bar")
 
             StitchFix::LogWeasel::Middleware.new(app).call(env)
+          end
+
+          context "also includes a header in the request" do
+            it "sets LogWeasel::Transation.id to the query string parameter value" do
+              allow(ENV).to receive(:fetch).with('LOG_WEASEL_FROM_PARAMS', nil).and_return(true)
+
+              expect(StitchFix::LogWeasel::Transaction).to receive(:id=).with("foo")
+
+              StitchFix::LogWeasel::Middleware.new(app).call(env)
+            end
           end
         end
       end

--- a/spec/log_weasel/middleware_spec.rb
+++ b/spec/log_weasel/middleware_spec.rb
@@ -69,6 +69,22 @@ describe StitchFix::LogWeasel::Middleware do
         end
       end
 
+      context "when the log weasel id is included in the params" do
+        let(:env) do
+          Rack::MockRequest.env_for("something", params: { logweasel_id: 'foo' })
+        end
+
+        context "with the environment variable enabled" do
+          it "sets LogWeasel::Transation.id to the parameter value" do
+            allow(ENV).to receive(:fetch).with('LOGWEASEL_FROM_PARAMS', nil).and_return(true)
+
+            expect(StitchFix::LogWeasel::Transaction).to receive(:id=).with("foo")
+
+            StitchFix::LogWeasel::Middleware.new(app).call(env)
+          end
+        end
+      end
+
       context "ensure block" do
         let(:env) { {} }
 

--- a/spec/log_weasel/middleware_spec.rb
+++ b/spec/log_weasel/middleware_spec.rb
@@ -85,7 +85,7 @@ describe StitchFix::LogWeasel::Middleware do
             StitchFix::LogWeasel::Middleware.new(app).call(env)
           end
 
-          context "also includes a header in the request" do
+          context "a request without the log weasel headers" do
             it "sets LogWeasel::Transation.id to the query string parameter value" do
               allow(ENV).to receive(:fetch).with('LOG_WEASEL_FROM_PARAMS', nil).and_return(true)
 


### PR DESCRIPTION
## Problem

https://github.com/stitchfix/csp-report-service/pull/39 did a proof of concept on ways to pull a log weasel transaction id out of parameters _instead of just from the headers_.  @almostwhitehat and @rdadlani are more of the experts in "why" this is - but my understanding is these requests will be coming from a user's browser, using built in CSP functionality so modifying headers for the request isn't possible, _but_ adding query strings are.  One of our front end apps would be responsible for generating and returning the value to be used by the browser as shown [here](https://github.com/stitchfix/doompatrol/pull/5/files#diff-55c5b7aecfb519d0e4880eaf2788eb6eR34-R36)

So `TL;DR` it would be nice - in this case - to be able to grab the "existing" transaction ID from the params of the request, and use that to correlate events in multiple systems together.

## Solution

Add an environment variable check to toggle the functionality in the middleware component of log weasel, if this environment variable is set - and there is a value at the specified key in the query string, use that value to set the `StitchFix::LogWeasel::Transaction.id` instead of any header values.

## Checklist

### Before Merging

- [x] If there is an RC on this branch, revert the version change in `version.rb`

### After Merging

See the [gem release process](https://github.com/stitchfix/eng-wiki/blob/master/technical-topics/updating-gem-versions.md) for a detailed list, but the gist of it is:

- [x] Fetch `master` locally and run the applicable `rake version:*` task **on `master`** to bump the version
- [x] Run `rake release` **on `master`** to release the new version on Gemfury
- [ ] Add [release notes](https://github.com/stitchfix/log_weasel/releases) - **this is very important in helping other engineers understand what changed in the new version**
