### PR TITLE
We want to support the header that all the algo pyhton apps use for f…

### DIFF
--- a/lib/stitch_fix/log_weasel/middleware.rb
+++ b/lib/stitch_fix/log_weasel/middleware.rb
@@ -5,6 +5,7 @@ module StitchFix
     KEY_HEADER = 'X_LOGWEASEL_KEY'
     CORRELATION_ID_KEY = "HTTP_X_CORRELATION_ID"
     REQUEST_ID_KEY = "HTTP_X_REQUEST_ID"
+    STITCHFIX_REQUEST_ID_KEY = "HTTP_STITCHFIX_REQUEST_ID"
     PARAMS_KEY = "logweasel_id"
 
     def initialize(app, options = {})
@@ -15,7 +16,10 @@ module StitchFix
     # Future: Maybe add X-Amzn-Trace-Id request header for tracing through load balancer
     # (http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html)
     def call(env)
-      x_correlation_id = env.fetch(REQUEST_ID_KEY, nil) || env.fetch(CORRELATION_ID_KEY, nil) || log_weasel_id_from_params(env)
+      x_correlation_id = env.fetch(REQUEST_ID_KEY, nil) ||
+        env.fetch(CORRELATION_ID_KEY, nil) ||
+        env.fetch(STITCHFIX_REQUEST_ID_KEY, nil) ||
+        log_weasel_id_from_params(env)
 
       if x_correlation_id
         LogWeasel::Transaction.id = x_correlation_id

--- a/spec/log_weasel/middleware_spec.rb
+++ b/spec/log_weasel/middleware_spec.rb
@@ -24,6 +24,15 @@ describe StitchFix::LogWeasel::Middleware do
         end
       end
 
+      context "when an StitchFix::LogWeasel::Middleware::STITCHFIX_REQUEST_ID_KEY header is present" do
+        let(:env) { {StitchFix::LogWeasel::Middleware::STITCHFIX_REQUEST_ID_KEY => "1234"} }
+
+        it "sets LogWeasel::Transation.id to the X-Correlation-Id value" do
+          expect(StitchFix::LogWeasel::Transaction).to receive(:id=).with("1234")
+          StitchFix::LogWeasel::Middleware.new(app).call(env)
+        end
+      end
+
       context "when an StitchFix::LogWeasel::Middleware::REQUEST_ID_KEY header is present" do
         let(:env) { {StitchFix::LogWeasel::Middleware::REQUEST_ID_KEY => "1234"} }
 


### PR DESCRIPTION
…orwarding trace headers

* this should let us have end to end tracing when a request goes eng -> algo -> eng, we would have the same logweaseal trace_id
* we will likely extend this to accept open_trace headers in the future as both Algo and Eng will plan to support those

## Problem

currently, Algo uses a difference header than we do to propagate trace_ids, we want to support theirs as well to get end to end traces. 

## Solution

Also, pull the `STITCHFIX_REQUEST_ID` header when present.

## Checklist

### Before Merging

- [ ] If there is an RC on this branch, revert the version change in `version.rb`

### After Merging

See the [gem release process](https://github.com/stitchfix/eng-wiki/blob/master/technical-topics/updating-gem-versions.md) for a detailed list, but the gist of it is:

- [ ] Fetch `master` locally and run the applicable `rake version:*` task **on `master`** to bump the version
- [ ] Run `rake release` **on `master`** to release the new version on Gemfury
- [ ] Add [release notes](https://github.com/stitchfix/log_weasel/releases) - **this is very important in helping other engineers understand what changed in the new version**
