### PR TITLE
add support for cookie traces

### DIFF
--- a/spec/log_weasel/middleware_spec.rb
+++ b/spec/log_weasel/middleware_spec.rb
@@ -106,6 +106,36 @@ describe StitchFix::LogWeasel::Middleware do
         end
       end
 
+      context "when the log weasel id is included in the cookies" do
+        let(:env) do
+          Rack::MockRequest.env_for("something", "HTTP_COOKIE" => 'logweasel_cookie_trace=cookietrace;')
+        end
+
+        context "with the environment variable enabled" do
+          it "sets LogWeasel::Transation.id to the header value" do
+            allow(ENV).to receive(:fetch).with('LOG_WEASEL_FROM_PARAMS', nil).and_return(nil)
+            allow(ENV).to receive(:fetch).with('LOG_WEASEL_FROM_COOKIE', nil).and_return(true)
+
+            env['HTTP_X_REQUEST_ID'] = 'bar'
+
+            expect(StitchFix::LogWeasel::Transaction).to receive(:id=).with("bar")
+
+            StitchFix::LogWeasel::Middleware.new(app).call(env)
+          end
+
+          context "a request without the log weasel headers" do
+            it "sets LogWeasel::Transation.id to the query string parameter value" do
+              allow(ENV).to receive(:fetch).with('LOG_WEASEL_FROM_PARAMS', nil).and_return(nil)
+              allow(ENV).to receive(:fetch).with('LOG_WEASEL_FROM_COOKIE', nil).and_return(true)
+
+              expect(StitchFix::LogWeasel::Transaction).to receive(:id=).with("cookietrace")
+
+              StitchFix::LogWeasel::Middleware.new(app).call(env)
+            end
+          end
+        end
+      end
+
       context "when the log weasel id is not included in the params" do
         let(:env) do
           Rack::MockRequest.env_for("something", params: { something_else: 'foo' })

--- a/spec/log_weasel/middleware_spec.rb
+++ b/spec/log_weasel/middleware_spec.rb
@@ -124,7 +124,7 @@ describe StitchFix::LogWeasel::Middleware do
           end
 
           context "a request without the log weasel headers" do
-            it "sets LogWeasel::Transation.id to the query string parameter value" do
+            it "sets LogWeasel::Transation.id to the cookie value" do
               allow(ENV).to receive(:fetch).with('LOG_WEASEL_FROM_PARAMS', nil).and_return(nil)
               allow(ENV).to receive(:fetch).with('LOG_WEASEL_FROM_COOKIE', nil).and_return(true)
 


### PR DESCRIPTION
## Problem

When pushing a developer defined trace_id through the system, we can only define it on the initial request, so much of our UI now does work on secondary ajax requests that you can't set the trace in a useful way for dev tests.

## Solution

Similar to the log_weasel from params, we can allow from a cookie... Neither of these features is useful or desired in standard use, which is why they are disabled by default and have to be turned on with ENV vars `LOG_WEASEL_FROM_COOKIE=true`. This will pick up a trace from a cookie and allow it to be on the initial request as well as the ajax requests.

## Checklist

### Before Merging

- [ ] If there is an RC on this branch, revert the version change in `version.rb`

### After Merging

See the [gem release process](https://github.com/stitchfix/eng-wiki/blob/master/technical-topics/updating-gem-versions.md) for a detailed list, but the gist of it is:

- [ ] Fetch `master` locally and run the applicable `rake version:*` task **on `master`** to bump the version
- [ ] Run `rake release` **on `master`** to release the new version on Gemfury
- [ ] Add [release notes](https://github.com/stitchfix/log_weasel/releases) - **this is very important in helping other engineers understand what changed in the new version**
