### PR TITLE
Update LWID extension for JS

### DIFF
--- a/src/stitch_fix/__tests__/logWeaselTest.test.js
+++ b/src/stitch_fix/__tests__/logWeaselTest.test.js
@@ -12,7 +12,7 @@ describe('generateId', () => {
   });
 
   it('returns a Log Weasel ID', () => {
-    expect(LogWeasel.generateId()).toMatch(/^[0-9A-Z]{26}-WEASEL-WEB$/);
+    expect(LogWeasel.generateId()).toMatch(/^[0-9A-Z]{26}-WEASEL-JS$/);
   });
 
   it('returns a different Log Weasel ID each time it is called', () => {

--- a/src/stitch_fix/logWeasel.js
+++ b/src/stitch_fix/logWeasel.js
@@ -12,7 +12,7 @@ const LogWeasel = {
   },
 
   generateId: () => {
-    const formattedKey = `${globalKey}-WEB`;
+    const formattedKey = `${globalKey}-JS`;
 
     return `${ulid()}-${formattedKey}`;
   },


### PR DESCRIPTION
## Problem

Log Weasel adds an extension to the Log Weasel ID that indicates the context in which the ID originated. For web requests, it uses `-WEB` as the extension. For Resque jobs, it uses `-RESQUE` as the extension. But for requests originating in javascript, we are currently using `-WEB`.

## Solution

Update the extension to `-JS` for requests that originate from javascript.

## Checklist

### Before Merging

- [ ] If there is an RC on this branch, revert the version change in `version.rb`

### After Merging

See the [gem release process](https://github.com/stitchfix/eng-wiki/blob/master/technical-topics/updating-gem-versions.md) for a detailed list, but the gist of it is:

- [ ] Fetch `master` locally and run the applicable `rake version:*` task **on `master`** to bump the version
- [ ] Run `rake release` **on `master`** to release the new version on Gemfury
- [ ] Add [release notes](https://github.com/stitchfix/log_weasel/releases) - **this is very important in helping other engineers understand what changed in the new version**
