### PR TITLE
Avoid overwriting singleton init state when more than one user of LW exists in an application (Breaking change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,50 @@
 # Log Weasel
 
-Instrument Rails and supported 3rd-party libraries (e.g. Resque, Pwwka) with shared transaction IDs to trace execution of a unit of work across
-applications and application instances.
+Instrument Rails and supported 3rd-party libraries (e.g. Resque, Pwwka) with shared transaction IDs to trace execution of a unit of work across applications and application instances.
 
+## JavaScript
 
-## Installation
+### Installation
+Install the Log Weasel JS package with yarn:
+
+```
+yarn add @stitch-fix/log-weasel
+```
+
+### Usage
+
+#### `generateId(appName)`
+
+Use `generateId` to generate correlation ids for xhr requests. These are generally attached to a request in an `x-request-id` header.
+
+##### `appName`
+
+The canonical fixops app name. It's converted to CONSTANT_CASE internally.
+
+##### Example
+
+```js
+import generateId from "@stitch-fix/log-weasel";
+
+// Get the app name from the app's package.json. Some apps 
+// expose this as a gon variable.
+import { name } from '../../package.json';
+
+const url = 'https://my-app.com/api';
+
+const post = (body) => { 
+  fetch(url, {
+    body,
+    headers: {
+      // Every call to generateId will create a unique trace ID
+      'X-Request-Id': generateId(name),
+    },
+  });
+```
+
+## Rails
+
+### Installation
 
 Add log_weasel to your Gemfile:
 
@@ -18,44 +58,19 @@ Use bundler to install it:
 bundle install
 ```
 
-Or, to use the Log Weasel NPM package, add it:
+### Setup
 
-```
-yarn add @stitch-fix/log-weasel
-```
-
-## Stitch Fix
 See [this setup guide](https://github.com/stitchfix/eng-wiki/blob/master/technical-topics/log-weasel-configuration.md) for how to configure Log Weasel for Rails applications at Stitch Fix.
-
-## Rails
 
 For Rails projects, we provide a Railtie that automatically configures and loads Log Weasel.
 
-To see Log Weasel transaction IDs in your Rails logs either use the Logger provided or
-customize the formatting of your logger to include `LogWeasel::Transaction.id`.
+To see Log Weasel transaction IDs in your Rails logs either use the Logger provided or customize the formatting of your logger to include `LogWeasel::Transaction.id`.
 
 ```rb
 YourApp::Application.configure do
   config.log_weasel.key = 'YOUR_APP'    # Optional. Defaults to Rails application name.
 end
 ```
-
-## Javascript
-
-If you have added the optional NPM package, this is how you would use it:
-
-```js
-import LogWeasel from "@stitch-fix/log-weasel";
-// Get the canonical fixops app name from your app's package.json
-import { name } from '../../package.json';
-
-LogWeasel.init(name);
-
-// Every call to generateId will create a unique trace ID
-const xRequestId = LogWeasel.generateId();
-```
-
-## Other
 
 ### Configure
 
@@ -70,12 +85,10 @@ end
 ```
 
 `config.key`  (default is the Rails `app_name`)  
-A string that will be included in your transaction IDs and is particularly
-useful in an environment where a unit of work may span multiple applications.  
+A string that will be included in your transaction IDs and is particularly useful in an environment where a unit of work may span multiple applications.  
 
 `config.disable_delayed_job_tracing` (default is `false`)  
-A boolean that disables Log Weasel appending a `log_weasel_id` parameter in 
-the payloads of delayed Resque jobs. The default is `false`. 
+A boolean that disables Log Weasel appending a `log_weasel_id` parameter in  the payloads of delayed Resque jobs. The default is `false`. 
 
 `config.debug` (default is `false`)  
 A boolean that enables some additional debug logging. The default is `false`. 
@@ -84,32 +97,27 @@ Setting these configuration options are optional, but you must call `LogWeasel.c
 
 ### Rack
 
-Log Weasel provides Rack middleware to create and destroy a transaction ID for every HTTP request. You can use it
-in a any web framework that supports Rack (Rails, Sinatra,...) by using `LogWeasel::Middleware` in your middleware
-stack.
+Log Weasel provides Rack middleware to create and destroy a transaction ID for every HTTP request. You can use it in a any web framework that supports Rack (Rails, Sinatra,...) by using `LogWeasel::Middleware` in your middleware stack.
 
 ### Log Weasel ID From Params
 
 The Log Weasel transaction id can also be passed via query string.  While this should not be necessary for common Stitch Fix engineering use cases, you can include a `logweasel_id` key in the query string and set `LOG_WEASEL_FROM_PARAMS` environment variable in your application via `fixops`.  **Note** this will take precedence over the values passed in the HTTP headers the Log Weasel middleware looks at.
 
-## Resque
+### Resque
 
-When you configure Log Weasel as described above either in Rails or by explicitly calling `LogWeasel.configure`,
-it modifies Resque to include transaction IDs in all worker logs.
+When you configure Log Weasel as described above either in Rails or by explicitly calling `LogWeasel.configure`, it modifies Resque to include transaction IDs in all worker logs.
 
 Start your Resque worker with `VERBOSE=1` and you'll see transaction IDs in your Resque logs.
 
-## Airbrake
+### Airbrake
 
-If you are using <a href="http://airbrake.io/p">Airbrake</a>, Log Weasel will add the parameter
-`log_weasel_id` to Airbrake errors so that you can track execution through your application stack that
-resulted in the error. No additional configuration required.
+If you are using <a href="http://airbrake.io/p">Airbrake</a>, Log Weasel will add the parameter `log_weasel_id` to Airbrake errors so that you can track execution through your application stack that resulted in the error. No additional configuration required.
 
-## Example
+### Example
 
 In this example we have a Rails app pushing jobs to Resque and a Resque worker that run with the Rails environment loaded.
 
-### HelloController
+#### HelloController
 
 ```rb
 class HelloController > ApplicationController
@@ -122,7 +130,7 @@ class HelloController > ApplicationController
 end
 ```
 
-### EchoJob
+#### EchoJob
 
 ```rb
 class EchoJob
@@ -177,19 +185,15 @@ and our resque log shows:
 *** SAMPLE_APP-RESQUE-00919a012476121cf89c done: (Job{default_queue} | EchoJob | ["hi from Rails console"] | {"log_weasel_id"=>"SAMPLE_APP-RESQUE-00919a012476121cf89c"})
 ```
 
-Units of work initiated from Resque, for example if using a scheduler like
-<a href="https://github.com/bvandenbos/resque-scheduler">resque-scheduler</a>,
-will include 'RESQUE' in the transaction ID to indicate that the work started in Resque.
+Units of work initiated from Resque, for example if using a scheduler like <a href="https://github.com/bvandenbos/resque-scheduler">resque-scheduler</a>, will include 'RESQUE' in the transaction ID to indicate that the work started in Resque.
 
 ## Contributing
 
-If you would like to contribute a fix or integrate Log Weasel transaction tracking into another frameworks
-please fork the code, add the fix or feature in your local project and then send a pull request on github.
-Please ensure that you include a test which verifies your changes.
+If you would like to contribute a fix or integrate Log Weasel transaction tracking into another frameworks please fork the code, add the fix or feature in your local project and then send a pull request on github. Please ensure that you include a test which verifies your changes.
 
 ## Authors
 
-<a href="http://github.com/asalant">Alon Salant</a> and <a href="http://github.com/brettfishman">Brett Fishman</a>.
+<a href="http://github.com/asalant">Alon Salant</a>, <a href="http://github.com/brettfishman">Brett Fishman</a>, and Rob Wierzbowski.
 
 ## LICENSE
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stitch-fix/log-weasel",
   "description": "Log Weasel Javascript client",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "author": "Stitch Fix",
   "license": "UNLICENSED",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
     "index.js",
     "src/stitch_fix/logWeasel.js"
   ],
-  "jest": {
-    "testURL": "http://localhost"
-  },
   "scripts": {
     "clean": "rm build/app.js",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "eslint-plugin-standard": "^4.0.1",
     "jest": "^25.1.0"
   },
-  "peerDependencies": {},
   "browserslist": [
     "extends @stitch-fix/browserslist-config-stitchfix"
   ]

--- a/src/stitch_fix/__tests__/__snapshots__/logWeaselTest.test.js.snap
+++ b/src/stitch_fix/__tests__/__snapshots__/logWeaselTest.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`init throws an error if key is not passed 1`] = `"LogWeasel.init requires a key argument"`;
+exports[`generateId throws an error if key is not passed 1`] = `"LogWeasel generateID requires a key argument"`;

--- a/src/stitch_fix/__tests__/logWeaselTest.test.js
+++ b/src/stitch_fix/__tests__/logWeaselTest.test.js
@@ -1,25 +1,20 @@
-import { LogWeasel } from '../logWeasel';
+import generateId from '../logWeasel';
 
-describe('init', () => {
-  it('throws an error if key is not passed', () => {
-    expect(() => LogWeasel.init()).toThrowErrorMatchingSnapshot();
-  });
-});
+const appName = 'weasel-gang-ui';
 
 describe('generateId', () => {
-  beforeAll(() => {
-    LogWeasel.init('weasel-gang-service');
+  it('throws an error if key is not passed', () => {
+    expect(() => generateId()).toThrowErrorMatchingSnapshot();
   });
 
   it('returns a Log Weasel ID with a constant case app name', () => {
-    expect(LogWeasel.generateId()).toMatch(/^[0-9A-Z]{26}-WEASEL_GANG_SERVICE-JS$/);
+    expect(generateId(appName)).toMatch(/^[0-9A-Z]{26}-WEASEL_GANG_UI-JS$/);
   });
 
   it('returns a different Log Weasel ID each time it is called', () => {
-    const firstId = LogWeasel.generateId();
-    const secondId = LogWeasel.generateId();
+    const firstId = generateId(appName);
+    const secondId = generateId(appName);
 
     expect(firstId).not.toEqual(secondId);
   });
 });
-

--- a/src/stitch_fix/logWeasel.js
+++ b/src/stitch_fix/logWeasel.js
@@ -1,19 +1,12 @@
 import { ulid } from 'ulid';
 import { constantCase } from 'constant-case';
 
-let globalKey;
+const generateId = (key) => {
+  if (typeof key === 'undefined') {
+    throw new TypeError('LogWeasel generateID requires a key argument');
+  }
 
-const LogWeasel = {
-  init: (key) => {
-    if (typeof key === 'undefined') {
-      throw new TypeError('LogWeasel.init requires a key argument');
-    }
-
-    globalKey = constantCase(key);
-  },
-
-  generateId: () => `${ulid()}-${globalKey}-JS`,
+  return `${ulid()}-${constantCase(key)}-JS`;
 };
 
-export { LogWeasel };
-export default LogWeasel;
+export default generateId;


### PR DESCRIPTION
## Problem

Because LW uses a singleton to track initialization state (the application name), any later initializations of LW can overwrite the original initialization values. Now that we are distributing components with LW in them, we are guaranteed to have multiple initializations. We already have 3 inits that overwrite themselves in KIUI – the app itself, ER, and the Graph API helper. So as the app runs, the supposedly universal app name is changed three times. This breaks the connection between the code a consumer of LW sets and the value of the header when sent, making it hard to infer what code sent what request.

## Solution

Instead of enabling spooky action at a distance, we’ll make log weasel a simple function with no initialization. If people want to standardize the name they’re passing in they can either pull it from a single source or make a wrapping function that contains a constant. This is a little more work but allows us to more easily trace xhr requests back to what called them.

## Todo

- [ ] release after merge
- [ ] convert all usage of LWJS to new functional usage (https://stitchfix.atlassian.net/browse/KFE-262)