### PR TITLE
Reference more modern node version

### DIFF
--- a/bin/additional-ci-steps
+++ b/bin/additional-ci-steps
@@ -4,7 +4,7 @@
 set -e
 
 # Install node
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
 sudo apt-get install -y nodejs
 
 # Install yarn


### PR DESCRIPTION
There was an old version of node referenced in `bin/additional-ci-steps` that no longer is supported. I updated this reference to the version that is our current standard - `14.x`.