### PR TITLE
Add global type defs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './src/stitch_fix/generateId';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stitch-fix/log-weasel",
   "description": "Log Weasel Javascript client",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": "Stitch Fix",
   "license": "UNLICENSED",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "author": "Stitch Fix",
   "license": "UNLICENSED",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": "https://github.com/stitchfix/log_weasel",
   "files": [
     "index.js",
+    "index.d.ts",
     "src/stitch_fix/generateId.js"
   ],
   "scripts": {

--- a/src/stitch_fix/generateId.d.ts
+++ b/src/stitch_fix/generateId.d.ts
@@ -1,3 +1,6 @@
+// Although this is not a TS package, types are exported to support TS
+// applications. Please keep the types here in sync with the type signature of
+// the export in generateId.js
 declare const generateId: (key: string) => string;
 
 export default generateId;

--- a/src/stitch_fix/generateId.d.ts
+++ b/src/stitch_fix/generateId.d.ts
@@ -1,0 +1,3 @@
+declare const generateId: (key: string) => string;
+
+export default generateId;

--- a/src/stitch_fix/generateId.js
+++ b/src/stitch_fix/generateId.js
@@ -1,6 +1,8 @@
 import { ulid } from 'ulid';
 import { constantCase } from 'constant-case';
 
+// Keep the type signature of this function in sync with the types exposed in
+// index.d.ts
 const generateId = (key) => {
   if (typeof key === 'undefined') {
     throw new TypeError('LogWeasel generateID requires a key argument');

--- a/src/stitch_fix/generateId.js
+++ b/src/stitch_fix/generateId.js
@@ -1,8 +1,9 @@
 import { ulid } from 'ulid';
 import { constantCase } from 'constant-case';
 
-// Keep the type signature of this function in sync with the types exposed in
-// index.d.ts
+// Although this is not a TS package, types are exported to support TS
+// applications. Please keep the type signature of this function in sync with
+// the types exposed in generateId.d.ts
 const generateId = (key) => {
   if (typeof key === 'undefined') {
     throw new TypeError('LogWeasel generateID requires a key argument');


### PR DESCRIPTION
## Problem

Although the JS package isn't written in TS, it's a pain for TS apps to add a module declaration file when they need to use it. The types also need to be exposed through packages like ER that are in TS, and are consumed by TS apps.

## Solution

Expose a global TS module def. Check in a TS aware application that this works as expected when importing Log Weasel directly.

![image](https://user-images.githubusercontent.com/925735/131371876-7ad79129-9040-43c1-997d-f4007b34beb2.png)

## TODO

After merge:
- [ ] Publish
- [ ] make sure this also works as expected when importing ER into a TS application.