### PR TITLE
Add pull request template with gem release instructions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,8 +14,8 @@
 
 ### After Merging
 
-See the [gem release process](https://github.com/stitchfix/eng-wiki/blob/master/technical-topics/updating-gem-versions.md) for a detailed list, but the gist of it is:
+See the [gem release process](https://github.com/stitchfix/eng-wiki/blob/main/technical-topics/updating-gem-versions.md) for a detailed list, but the gist of it is:
 
-- [ ] Fetch `master` locally and run the applicable `rake version:*` task **on `master`** to bump the version
-- [ ] Run `rake release` **on `master`** to release the new version on Gemfury
+- [ ] Fetch `main` locally and run the applicable `rake version:*` task **on `main`** to bump the version
+- [ ] Run `rake release` **on `main`** to release the new version
 - [ ] Add [release notes](https://github.com/stitchfix/log_weasel/releases) - **this is very important in helping other engineers understand what changed in the new version**


### PR DESCRIPTION
## Problem

We have a Ruby Gem release process, but it is not always discoverable when merging a pull request in a gem.

## Solution

Add a pull request template with a link to the gem release process and a checklist of the high-level release steps.

Please review the diff and merge this PR if it looks good.

Note that if there was an existing PR template for this gem, the goro process that opened this PR replaced the existing template with new content. In this case, it's up to you to reconcile the diff and combine any existing content with the updates in a way that makes sense for this gem.