### PR TITLE
Add Sidekiq support for LogWeasel

### DIFF
--- a/lib/stitch_fix/log_weasel.rb
+++ b/lib/stitch_fix/log_weasel.rb
@@ -49,6 +49,10 @@ module StitchFix
 
         StitchFix::LogWeasel::ResqueScheduler.initialize!
       end
+
+      if defined? ::Sidekiq
+        StitchFix::LogWeasel::Sidekiq.initialize!
+      end
     end
   end
 end

--- a/lib/stitch_fix/log_weasel.rb
+++ b/lib/stitch_fix/log_weasel.rb
@@ -4,6 +4,7 @@ require 'stitch_fix/log_weasel/airbrake'
 require 'stitch_fix/log_weasel/middleware'
 require 'stitch_fix/log_weasel/resque'
 require 'stitch_fix/log_weasel/pwwka'
+require 'stitch_fix/log_weasel/sidekiq'
 require 'stitch_fix/log_weasel/railtie' if defined? ::Rails::Railtie
 
 module StitchFix

--- a/lib/stitch_fix/log_weasel/sidekiq.rb
+++ b/lib/stitch_fix/log_weasel/sidekiq.rb
@@ -4,6 +4,20 @@ module StitchFix
   module LogWeasel::Sidekiq
     LOG_WEASEL_CONTEXT_KEY = "log_weasel_id"
 
+    def self.initialize!
+      Sidekiq.configure_client do |sidekiq|
+        sidekiq.client_middleware do |chain|
+          chain.add ClientMiddleware
+        end
+      end
+
+      Sidekiq.configure_server do |sidekiq|
+        sidekiq.server_middleware do |chain|
+          chain.add ServerMiddleware
+        end
+      end
+    end
+
     def self.transaction_key
       LogWeasel.config.key ? "#{LogWeasel.config.key}-SIDEKIQ" : "SIDEKIQ"
     end

--- a/lib/stitch_fix/log_weasel/sidekiq.rb
+++ b/lib/stitch_fix/log_weasel/sidekiq.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module StitchFix
+  module LogWeasel::Sidekiq
+    LOG_WEASEL_CONTEXT_KEY = "log_weasel_id"
+
+    def self.transaction_key
+      LogWeasel.config.key ? "#{LogWeasel.config.key}-SIDEKIQ" : "SIDEKIQ"
+    end
+
+    class ClientMiddleware
+      def call(_worker_class, job, _queue, _redis_pool)
+
+        job[LOG_WEASEL_CONTEXT_KEY] = LogWeasel::Transaction.id || LogWeasel::Transaction.create(LogWeasel::Sidekiq.transaction_key)
+
+        yield
+      end
+    end
+
+    class ServerMiddleware
+      def call(worker, msg, queue_name)
+        if msg.has_key? LOG_WEASEL_CONTEXT_KEY
+          LogWeasel::Transaction.id = msg[LOG_WEASEL_CONTEXT_KEY]
+        else
+          LogWeasel::Transaction.create LogWeasel::Sidekiq.transaction_key
+        end
+
+        yield
+      end
+    end
+  end
+end

--- a/lib/stitch_fix/log_weasel/version.rb
+++ b/lib/stitch_fix/log_weasel/version.rb
@@ -1,5 +1,5 @@
 module StitchFix
   module LogWeasel
-    VERSION = "1.6.0"
+    VERSION = "1.7.0-RC"
   end
 end

--- a/lib/stitch_fix/log_weasel/version.rb
+++ b/lib/stitch_fix/log_weasel/version.rb
@@ -1,5 +1,5 @@
 module StitchFix
   module LogWeasel
-    VERSION = "1.7.0.RC"
+    VERSION = "1.6.0"
   end
 end

--- a/lib/stitch_fix/log_weasel/version.rb
+++ b/lib/stitch_fix/log_weasel/version.rb
@@ -1,5 +1,5 @@
 module StitchFix
   module LogWeasel
-    VERSION = "1.7.0-RC"
+    VERSION = "1.7.0.RC"
   end
 end

--- a/spec/log_weasel/log_weasel_spec.rb
+++ b/spec/log_weasel/log_weasel_spec.rb
@@ -17,6 +17,7 @@ describe StitchFix::LogWeasel do
       expect(StitchFix::LogWeasel::Pwwka).to receive(:initialize!)
       expect(StitchFix::LogWeasel::Resque).to receive(:initialize!)
       expect(StitchFix::LogWeasel::ResqueScheduler).to receive(:initialize!)
+      expect(StitchFix::LogWeasel::Sidekiq).to receive(:initialize!)
       StitchFix::LogWeasel.configure {}
     end
   end

--- a/spec/log_weasel/sidekiq_spec.rb
+++ b/spec/log_weasel/sidekiq_spec.rb
@@ -21,6 +21,27 @@ describe StitchFix::LogWeasel::Sidekiq do
     end
   end
 
+  describe "initialize!" do
+    after :each do
+      Sidekiq.client_middleware.clear
+      Sidekiq.server_middleware.clear
+    end
+
+    it "sets the client middleware" do
+      described_class.initialize!
+
+      expect(Sidekiq.client_middleware.map(&:klass)).to contain_exactly(described_class::ClientMiddleware)
+    end
+
+    it "sets the server middleware" do
+      allow(Sidekiq).to receive(:server?).and_return(true)
+
+      described_class.initialize!
+
+      expect(Sidekiq.server_middleware.map(&:klass)).to contain_exactly(described_class::ServerMiddleware)
+    end
+  end
+
   describe "client middleware" do
     around :each do |example|
       Sidekiq.configure_client do |sidekiq|

--- a/spec/log_weasel/sidekiq_spec.rb
+++ b/spec/log_weasel/sidekiq_spec.rb
@@ -1,0 +1,80 @@
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require 'sidekiq/testing'
+
+class TestWorker
+  include Sidekiq::Worker
+
+  def perform
+  end
+end
+
+describe StitchFix::LogWeasel::Sidekiq do
+  around :each do |example|
+    StitchFix::LogWeasel::Transaction.destroy
+    example.run
+    StitchFix::LogWeasel::Transaction.destroy
+  end
+
+  around :each do |example|
+    Sidekiq::Testing.fake! do
+      example.run
+    end
+  end
+
+  describe "client middleware" do
+    around :each do |example|
+      Sidekiq.configure_client do |sidekiq|
+        sidekiq.client_middleware do |chain|
+          chain.add described_class::ClientMiddleware
+        end
+      end
+
+      example.run
+
+      Sidekiq.configure_client do |sidekiq|
+        sidekiq.client_middleware.clear
+      end
+    end
+
+    it "sets a log_weasel_id on the job context" do
+      Sidekiq::Client.push(
+        {
+          "class" => "FakeJobClass",
+          "queue" => "default",
+          "args" => []
+        }
+      )
+
+      job = Sidekiq::Queues["default"].first
+      expect(job).to have_key(described_class::LOG_WEASEL_CONTEXT_KEY)
+      expect(job).to match(hash_including(described_class::LOG_WEASEL_CONTEXT_KEY => a_kind_of(String)))
+    end
+  end
+
+  describe "server middleware" do
+    before :each do
+      Sidekiq::Testing.server_middleware do |chain|
+        chain.add described_class::ServerMiddleware
+      end
+    end
+
+    it "uses any set log_weasel_id on the job context" do
+      job = {
+        "class" => TestWorker.name,
+        "queue" => "default",
+        "args" => [],
+        described_class::LOG_WEASEL_CONTEXT_KEY => "blah"
+      }
+      Sidekiq::Client.push(job)
+      TestWorker.perform_one
+
+      expect(StitchFix::LogWeasel::Transaction.id).to eq "blah"
+    end
+
+    it "create a log_weasel_id if none is present on the job" do
+      TestWorker.perform_async
+
+      expect { TestWorker.drain }.to change { StitchFix::LogWeasel::Transaction.id }.from(nil).to(a_kind_of(String))
+    end
+  end
+end

--- a/stitchfix-log_weasel.gemspec
+++ b/stitchfix-log_weasel.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec_junit_formatter')
   s.add_development_dependency('stitchfix-y')
   s.add_development_dependency('combustion')
+  s.add_development_dependency('sidekiq')
 
   s.add_dependency('activesupport')
   s.add_dependency('ulid')


### PR DESCRIPTION
## Problem

We don't have any support in Log Weasel for maintaining the transaction ID through Sidekiq Jobs.

## Solution

Add support similiar to that of Resque

Example of logs with log weasel trace id (all jobs started from a singular rake task): https://staging-stitchfix.datadoghq.com/logs?cols=&event&from_ts=1639668154099&index=&live=false&messageDisplay=inline&query=%40app.process_type%3Asidekiq+service%3Aproduct-catalog-service+%40log.log_weasel_trace_id%3A01FQ1XDBBSGB1KEN0XJ5CT0TVH-PRODUCTCATALOGSERVICE-SIDEKIQ&stream_sort=time%2Casc&to_ts=1639668241524

In conjunction with https://github.com/stitchfix/sidekiq_utils/pull/3

<img width="1727" alt="image" src="https://user-images.githubusercontent.com/3472781/146399577-6e9f716f-8d07-49d0-9ce6-c3ec08705095.png">


## Checklist

### Before Merging

- [x] If there is an RC on this branch, revert the version change in `version.rb`

### After Merging

See the [gem release process](https://github.com/stitchfix/eng-wiki/blob/main/technical-topics/updating-gem-versions.md) for a detailed list, but the gist of it is:

- [ ] Fetch `main` locally and run the applicable `rake version:*` task **on `main`** to bump the version
- [ ] Run `rake release` **on `main`** to release the new version
- [ ] Add [release notes](https://github.com/stitchfix/log_weasel/releases) - **this is very important in helping other engineers understand what changed in the new version**