### PR TITLE
Exclude JS src from gem files

### DIFF
--- a/stitchfix-log_weasel.gemspec
+++ b/stitchfix-log_weasel.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport')
   s.add_dependency('ulid')
 
-  s.files         = `git ls-files`.split("\n")
+  s.files         = `git ls-files`.split("\n").filter { |f| !f.start_with?("src") }
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]


### PR DESCRIPTION
## Problem

See issue #42 

## Solution

There are probably a number of ways to exclude `src` from the gemspec files list, such as with a inverted regex pattern or a Git-specific glob like `git ls-files -- . ':!:src*'`. I chose an approach I thought would be less obfuscated.

Fixes #42 