### PR TITLE
Replace pwwka with stitchfix-messaging

### DIFF
--- a/lib/stitch_fix/log_weasel/tasks.rb
+++ b/lib/stitch_fix/log_weasel/tasks.rb
@@ -1,6 +1,6 @@
 # vim:fileencoding=utf-8
 
-require 'pwwka/tasks'
+require 'stitch_fix/messaging'
 require 'resque/tasks'
 require 'resque/scheduler/tasks'
 

--- a/spec/log_weasel/log_weasel_spec.rb
+++ b/spec/log_weasel/log_weasel_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require 'pwwka'
+require 'stitch_fix/messaging'
 require 'resque'
 require 'stitch_fix/log_weasel'
 

--- a/spec/log_weasel/pwwka_spec.rb
+++ b/spec/log_weasel/pwwka_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require 'pwwka'
+require 'stitch_fix/messaging'
 
 describe StitchFix::LogWeasel::Pwwka do
 

--- a/stitchfix-log_weasel.gemspec
+++ b/stitchfix-log_weasel.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('gemfury')
   s.add_development_dependency('logger')
   s.add_development_dependency('mocha')
-  s.add_development_dependency('pwwka')
+  s.add_development_dependency('stitchfix-messaging')
   s.add_development_dependency('rake')
   s.add_development_dependency('resque')
   s.add_development_dependency('resque-scheduler')


### PR DESCRIPTION
## Problem

Tests were failing against Rails 7 because the `pwwka` library makes an unsupported (in Rails 7) call to `.parent` during initialization. 

```
Failure/Error: let(:publish_options) { Pwwka::PublishOptions.new(**options) }

NoMethodError:
  undefined method `parent' for Combustion::Application:Class
  Did you mean?  present?
/home/circleci/.rubygems/gems/railties-7.0.1/lib/rails/railtie.rb:226:in `method_missing'
/home/circleci/.rubygems/gems/pwwka-0.24.0/lib/pwwka/configuration.rb:55:in `app_id'
/home/circleci/.rubygems/gems/pwwka-0.24.0/lib/pwwka/publish_options.rb:16:in `initialize'
./spec/log_weasel/pwwka_spec.rb:62:in `new'
./spec/log_weasel/pwwka_spec.rb:62:in `block (5 levels) in <top (required)>'
./spec/log_weasel/pwwka_spec.rb:65:in `block (5 levels) in <top (required)>'
```

## Solution

Replace `pwwka` with `stitchfix-messaging`, which [has been updated](https://github.com/stitchfix/messaging/blob/main/pwwka/lib/pwwka/configuration.rb#L59) to deal with this issue.

## Checklist

### Before Merging

- [ ] If there is an RC on this branch, revert the version change in `version.rb`

### After Merging

See the [gem release process](https://github.com/stitchfix/eng-wiki/blob/main/technical-topics/updating-gem-versions.md) for a detailed list, but the gist of it is:

- [ ] Fetch `main` locally and run the applicable `rake version:*` task **on `main`** to bump the version
- [ ] Run `rake release` **on `main`** to release the new version
- [ ] Add [release notes](https://github.com/stitchfix/log_weasel/releases) - **this is very important in helping other engineers understand what changed in the new version**
