### PR TITLE
Revert "Replace pwwka with stitchfix-messaging"

### DIFF
--- a/lib/stitch_fix/log_weasel/tasks.rb
+++ b/lib/stitch_fix/log_weasel/tasks.rb
@@ -1,6 +1,6 @@
 # vim:fileencoding=utf-8
 
-require 'stitch_fix/messaging'
+require 'pwwka/tasks'
 require 'resque/tasks'
 require 'resque/scheduler/tasks'
 

--- a/spec/log_weasel/log_weasel_spec.rb
+++ b/spec/log_weasel/log_weasel_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require 'stitch_fix/messaging'
+require 'pwwka'
 require 'resque'
 require 'stitch_fix/log_weasel'
 

--- a/spec/log_weasel/pwwka_spec.rb
+++ b/spec/log_weasel/pwwka_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require 'stitch_fix/messaging'
+require 'pwwka'
 
 describe StitchFix::LogWeasel::Pwwka do
 

--- a/stitchfix-log_weasel.gemspec
+++ b/stitchfix-log_weasel.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('gemfury')
   s.add_development_dependency('logger')
   s.add_development_dependency('mocha')
-  s.add_development_dependency('stitchfix-messaging')
+  s.add_development_dependency('pwwka')
   s.add_development_dependency('rake')
   s.add_development_dependency('resque')
   s.add_development_dependency('resque-scheduler')


### PR DESCRIPTION
Reverts stitchfix/log_weasel#44

With support for Rails 7 introduced in [pwwka](https://github.com/stitchfix/pwwka/releases/tag/v1.0.0), there's no need to migrate to a private dependency.