### PR TITLE
Access origin of transaction

### DIFF
--- a/lib/stitch_fix/log_weasel/transaction.rb
+++ b/lib/stitch_fix/log_weasel/transaction.rb
@@ -4,6 +4,10 @@ module StitchFix
   module LogWeasel
     module Transaction
 
+      # UUIDs are from iOS and Android
+      UUID_REGEX_FORM = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-(?<scope>.+)/i # https://rubular.com/r/9XYz1jiWqZVpA1
+      ULID_REGEX_FORM = /[0-9a-z]{26}-(?<scope>.+)/i # https://rubular.com/r/4NjnyWRZVtz1gf
+
       def self.create(key = nil)
         Thread.current[:log_weasel_id] = "#{ULID.generate}#{key ? "-#{key}" : ""}"
       end
@@ -18,6 +22,13 @@ module StitchFix
 
       def self.id
         Thread.current[:log_weasel_id]
+      end
+
+      def self.scope
+        return unless self.id
+        match_data = self.id.match(ULID_REGEX_FORM) || self.id.match(UUID_REGEX_FORM)
+
+        match_data[:scope].downcase if match_data && match_data[:scope]
       end
     end
   end

--- a/lib/stitch_fix/log_weasel/transaction.rb
+++ b/lib/stitch_fix/log_weasel/transaction.rb
@@ -5,8 +5,8 @@ module StitchFix
     module Transaction
 
       # UUIDs are from iOS and Android
-      UUID_REGEX_FORM = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-(?<scope>.+)/i # https://rubular.com/r/9XYz1jiWqZVpA1
-      ULID_REGEX_FORM = /[0-9a-z]{26}-(?<scope>.+)/i # https://rubular.com/r/4NjnyWRZVtz1gf
+      UUID_REGEX_FORM = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-(?<key>.+)/i # https://rubular.com/r/9XYz1jiWqZVpA1
+      ULID_REGEX_FORM = /[0-9a-z]{26}-(?<key>.+)/i # https://rubular.com/r/4NjnyWRZVtz1gf
 
       def self.create(key = nil)
         Thread.current[:log_weasel_id] = "#{ULID.generate}#{key ? "-#{key}" : ""}"
@@ -24,11 +24,11 @@ module StitchFix
         Thread.current[:log_weasel_id]
       end
 
-      def self.scope
+      def self.key
         return unless self.id
         match_data = self.id.match(ULID_REGEX_FORM) || self.id.match(UUID_REGEX_FORM)
 
-        match_data[:scope].downcase if match_data && match_data[:scope]
+        match_data[:key].downcase if match_data && match_data[:key]
       end
     end
   end

--- a/lib/stitch_fix/log_weasel/version.rb
+++ b/lib/stitch_fix/log_weasel/version.rb
@@ -1,5 +1,5 @@
 module StitchFix
   module LogWeasel
-    VERSION = "1.10.0.RC"
+    VERSION = "1.9.1"
   end
 end

--- a/lib/stitch_fix/log_weasel/version.rb
+++ b/lib/stitch_fix/log_weasel/version.rb
@@ -1,5 +1,5 @@
 module StitchFix
   module LogWeasel
-    VERSION = "1.9.1"
+    VERSION = "1.10.0.RC"
   end
 end

--- a/spec/log_weasel/transaction_spec.rb
+++ b/spec/log_weasel/transaction_spec.rb
@@ -11,6 +11,60 @@ describe StitchFix::LogWeasel::Transaction do
     end
   end
 
+  describe ".scope" do
+    context "no transaction set" do
+      it "is nil" do
+        expect(StitchFix::LogWeasel::Transaction.scope).to be_nil
+      end
+    end
+
+    context "transaction set with ULID" do
+      context "includes a scope" do
+        let(:scope) { "TEST-SCOPE" }
+        before do
+          StitchFix::LogWeasel::Transaction.create scope
+        end
+
+        it "returns the proper scope" do
+          expect(StitchFix::LogWeasel::Transaction.scope).to eq scope.downcase
+        end
+      end
+
+      context "does not include a scope" do
+        before do
+          StitchFix::LogWeasel::Transaction.create
+        end
+
+        it "is nil" do
+          expect(StitchFix::LogWeasel::Transaction.scope).to be_nil
+        end
+      end
+    end
+
+    context "transaction set with UUID" do
+      context "includes a scope" do
+        let(:scope) { "TEST-SCOPE" }
+        before do
+          StitchFix::LogWeasel::Transaction.id = "00660D68-3BFC-4E44-8DBD-66B0A878686A-#{scope}"
+        end
+
+        it "returns the proper scope" do
+          expect(StitchFix::LogWeasel::Transaction.scope).to eq scope.downcase
+        end
+      end
+
+      context "does not include a scope" do
+        before do
+          StitchFix::LogWeasel::Transaction.id = "00660D68-3BFC-4E44-8DBD-66B0A878686A"
+        end
+
+        it "is nil" do
+          expect(StitchFix::LogWeasel::Transaction.scope).to be_nil
+        end
+      end
+    end
+  end
+
   describe ".id=" do
     before do
       StitchFix::LogWeasel::Transaction.id = "1234"

--- a/spec/log_weasel/transaction_spec.rb
+++ b/spec/log_weasel/transaction_spec.rb
@@ -11,55 +11,55 @@ describe StitchFix::LogWeasel::Transaction do
     end
   end
 
-  describe ".scope" do
+  describe ".key" do
     context "no transaction set" do
       it "is nil" do
-        expect(StitchFix::LogWeasel::Transaction.scope).to be_nil
+        expect(StitchFix::LogWeasel::Transaction.key).to be_nil
       end
     end
 
     context "transaction set with ULID" do
-      context "includes a scope" do
-        let(:scope) { "TEST-SCOPE" }
+      context "includes a key" do
+        let(:key) { "TEST-KEY" }
         before do
-          StitchFix::LogWeasel::Transaction.create scope
+          StitchFix::LogWeasel::Transaction.create key
         end
 
-        it "returns the proper scope" do
-          expect(StitchFix::LogWeasel::Transaction.scope).to eq scope.downcase
+        it "returns the proper key" do
+          expect(StitchFix::LogWeasel::Transaction.key).to eq key.downcase
         end
       end
 
-      context "does not include a scope" do
+      context "does not include a key" do
         before do
           StitchFix::LogWeasel::Transaction.create
         end
 
         it "is nil" do
-          expect(StitchFix::LogWeasel::Transaction.scope).to be_nil
+          expect(StitchFix::LogWeasel::Transaction.key).to be_nil
         end
       end
     end
 
     context "transaction set with UUID" do
-      context "includes a scope" do
-        let(:scope) { "TEST-SCOPE" }
+      context "includes a key" do
+        let(:key) { "TEST-KEY" }
         before do
-          StitchFix::LogWeasel::Transaction.id = "00660D68-3BFC-4E44-8DBD-66B0A878686A-#{scope}"
+          StitchFix::LogWeasel::Transaction.id = "00660D68-3BFC-4E44-8DBD-66B0A878686A-#{key}"
         end
 
-        it "returns the proper scope" do
-          expect(StitchFix::LogWeasel::Transaction.scope).to eq scope.downcase
+        it "returns the proper key" do
+          expect(StitchFix::LogWeasel::Transaction.key).to eq key.downcase
         end
       end
 
-      context "does not include a scope" do
+      context "does not include a key" do
         before do
           StitchFix::LogWeasel::Transaction.id = "00660D68-3BFC-4E44-8DBD-66B0A878686A"
         end
 
         it "is nil" do
-          expect(StitchFix::LogWeasel::Transaction.scope).to be_nil
+          expect(StitchFix::LogWeasel::Transaction.key).to be_nil
         end
       end
     end


### PR DESCRIPTION
## Problem

Given that Stitch Fix has shared backend services for multiple front-end systems, it can be helpful to break out Datadog stats, metrics, and logs by the origin of a request. 

Example: for a client-facing functionality which is supported by Client Service, quickly knowing if a number of errors are coming from iOS, Android, or Web can narrow down if an issue is isolated to a particular front-end system.

We have two examples where this is used:
* [Financial Transaction Service](https://github.com/stitchfix/financial-transaction-service/blob/5fd2235c928ef32077588322cf08f5081000c4ca/lib/log_weasel_id.rb)
* [Client Service auth stats](https://github.com/stitchfix/client-service/blob/main/app/controllers/concerns/unified_auth_stats.rb)

We have another possible use coming up (stats from Client Auth API). Instead of replicating this logic yet again, we should make it available via gem.

## Solution

Add method to parse out the "scope" of a transaction ID. In the above implementations, FTS calls this a "scope", Client Service calls it "source_app"; we should discuss to get a name that makes sense. For now, I am going with the FTS name. (Looking at the logger gem, scope might get confused with authentication scope). 

## Checklist

### Before Merging

- [ ] If there is an RC on this branch, revert the version change in `version.rb`

### After Merging

See the [gem release process](https://github.com/stitchfix/eng-wiki/blob/main/technical-topics/updating-gem-versions.md) for a detailed list, but the gist of it is:

- [ ] Fetch `main` locally and run the applicable `rake version:*` task **on `main`** to bump the version
- [ ] Run `rake release` **on `main`** to release the new version
- [ ] Add [release notes](https://github.com/stitchfix/log_weasel/releases) - **this is very important in helping other engineers understand what changed in the new version**
