### PR TITLE
Fix middleware access for Sidekiq 7

### DIFF
--- a/spec/log_weasel/sidekiq_spec.rb
+++ b/spec/log_weasel/sidekiq_spec.rb
@@ -23,14 +23,18 @@ describe StitchFix::LogWeasel::Sidekiq do
 
   describe "initialize!" do
     after :each do
-      Sidekiq.client_middleware.clear
-      Sidekiq.server_middleware.clear
+      Sidekiq.configure_client do |sidekiq|
+        sidekiq.client_middleware.clear
+        sidekiq.server_middleware.clear
+      end
     end
 
     it "sets the client middleware" do
       described_class.initialize!
 
-      expect(Sidekiq.client_middleware.map(&:klass)).to contain_exactly(described_class::ClientMiddleware)
+      Sidekiq.configure_client do |sidekiq|
+        expect(sidekiq.client_middleware.map(&:klass)).to contain_exactly(described_class::ClientMiddleware)
+      end
     end
 
     it "sets the server middleware" do
@@ -38,7 +42,9 @@ describe StitchFix::LogWeasel::Sidekiq do
 
       described_class.initialize!
 
-      expect(Sidekiq.server_middleware.map(&:klass)).to contain_exactly(described_class::ServerMiddleware)
+      Sidekiq.configure_client do |sidekiq|
+        expect(sidekiq.server_middleware.map(&:klass)).to contain_exactly(described_class::ServerMiddleware)
+      end
     end
   end
 


### PR DESCRIPTION
## Problem

New build errors due to Sidekiq 7: https://app.circleci.com/pipelines/github/stitchfix/log_weasel/816/workflows/cc90c2e2-0acf-4ccc-b386-4d5beb2b44f9/jobs/6689/steps

The global `Sidekiq.client_middleware` and `Sidekiq.server_middleware` methods were removed. This only appears to impact how we are testing initialization. 

## Solution

Fix access to `client_middleware` and `server_middleware`

## Checklist

### Before Merging

- [ ] If there is an RC on this branch, revert the version change in `version.rb`

### After Merging

See the [gem release process](https://github.com/stitchfix/eng-wiki/blob/main/technical-topics/updating-gem-versions.md) for a detailed list, but the gist of it is:

- [ ] Fetch `main` locally and run the applicable `rake version:*` task **on `main`** to bump the version
- [ ] Run `rake release` **on `main`** to release the new version
- [ ] Add [release notes](https://github.com/stitchfix/log_weasel/releases) - **this is very important in helping other engineers understand what changed in the new version**
