### PR TITLE
Update CODEOWNERS: app-platform

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,4 @@
 # See https://help.github.com/articles/about-codeowners/ for more details.
 
 * @stitchfix/client-identity-access-management
+* @stitchfix/app-platform


### PR DESCRIPTION
## Problem

app-platform owns most the Stitch Fix logging libraries, but not this one.

## Solution

Add this repo to our collection
