### PR TITLE
Add bundler/gem_tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ require 'bundler'
 Bundler.setup
 
 require 'rspec'
+require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubygems/package_task'
 


### PR DESCRIPTION
## Problem

We use `bundle exec rake build`, which is a bundler provided task

## Solution

* Add `require 'bundler/gem_tasks'`
