### PR TITLE
Update CODEOWNERS to @stitchfix/platform-insights-and-reliability-engineering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           fi
     - run:
         name: Notify Pager Duty
-        command: bundle exec y-notify "#app-platform-ops"
+        command: bundle exec y-notify "#pire-ops"
         when: on_fail
     - store_test_results:
         path: "/tmp/test-results"
@@ -116,7 +116,7 @@ jobs:
           fi
     - run:
         name: Notify Pager Duty
-        command: bundle exec y-notify "#app-platform-ops"
+        command: bundle exec y-notify "#pire-ops"
         when: on_fail
     - store_test_results:
         path: "/tmp/test-results"
@@ -146,7 +146,7 @@ jobs:
           fi
     - run:
         name: Notify Pager Duty
-        command: bundle exec y-notify "#app-platform-ops"
+        command: bundle exec y-notify "#pire-ops"
         when: on_fail
     - store_test_results:
         path: "/tmp/test-results"
@@ -176,7 +176,7 @@ jobs:
           fi
     - run:
         name: Notify Pager Duty
-        command: bundle exec y-notify "#app-platform-ops"
+        command: bundle exec y-notify "#pire-ops"
         when: on_fail
     - store_test_results:
         path: "/tmp/test-results"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 # See https://help.github.com/articles/about-codeowners/ for more details.
 
 * @stitchfix/client-identity-access-management
-* @stitchfix/app-platform
+* @stitchfix/platform-insights-and-reliability-engineering


### PR DESCRIPTION
This PR updates CODEOWNERS entries from `@stitchfix/app-platform` to `@stitchfix/platform-insights-and-reliability-engineering`.